### PR TITLE
feat: add Firefox (MV2) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 
 # Build output
 dist/
+dist-firefox/
 coverage/
 generated/
 .model-sources/

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,0 +1,78 @@
+{
+  "manifest_version": 2,
+  "name": "Privacy Guardrail",
+  "version": "0.2.3",
+  "description": "Review and replace personal data in text before pasting into LLM chats. Runs locally in your browser. Assistive only.",
+  "browser_specific_settings": {
+    "gecko": {
+      "strict_min_version": "128.0"
+    }
+  },
+  "permissions": [
+    "storage",
+    "tabs",
+    "https://chat.openai.com/*",
+    "https://chatgpt.com/*",
+    "https://claude.ai/*",
+    "https://gemini.google.com/*"
+  ],
+  "background": {
+    "scripts": ["background/background.js"],
+    "persistent": true
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://chatgpt.com/*",
+        "https://claude.ai/*",
+        "https://gemini.google.com/*"
+      ],
+      "js": [
+        "content/content-script.js"
+      ],
+      "css": [
+        "ui/banner/de-anon-banner.css"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://chatgpt.com/*",
+        "https://claude.ai/*",
+        "https://gemini.google.com/*"
+      ],
+      "js": [
+        "content/clipboard-interceptor-injector.js"
+      ],
+      "run_at": "document_start"
+    }
+  ],
+  "options_page": "options/options.html",
+  "browser_action": {
+    "default_popup": "popup/popup.html",
+    "default_icon": {
+      "16": "assets/icons/dark-16.png",
+      "32": "assets/icons/inactive-32.png",
+      "48": "assets/icons/dark-48.png",
+      "128": "assets/icons/dark-128.png"
+    }
+  },
+  "web_accessible_resources": [
+    "wasm/*.wasm",
+    "content/clipboard-interceptor-page.js",
+    "models/ner/hikmaai-distilbert-pii/*",
+    "models/ner/hikmaai-distilbert-pii/onnx/*",
+    "models/ner/bardsai-eu-pii-anonimization-multilang/*",
+    "models/ner/bardsai-eu-pii-anonimization-multilang/onnx/*",
+    "vendor/onnxruntime-web/*"
+  ],
+  "icons": {
+    "16": "assets/icons/icon16.png",
+    "32": "assets/icons/icon32.png",
+    "48": "assets/icons/icon48.png",
+    "128": "assets/icons/icon128.png"
+  },
+  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
   "scripts": {
     "build:wasm": "cd crate && cargo build --release --target wasm32-unknown-unknown && wasm-bindgen --target web --out-dir pkg --out-name privacy_guardrail_wasm target/wasm32-unknown-unknown/release/privacy_guardrail_wasm.wasm",
     "build:ext": "webpack --mode production",
+    "build:ext:firefox": "BROWSER=firefox webpack --mode production",
+    "build:firefox": "npm run build:wasm && npm run build:ext:firefox",
     "build": "npm run build:wasm && npm run build:ext",
     "dev": "webpack --mode development --watch",
+    "dev:firefox": "BROWSER=firefox webpack --mode development --watch",
     "prepare:model:ai4privacy": "node scripts/prepare-ai4privacy-model.js",
     "prepare:model:bardsai": "node scripts/prepare-bardsai-model.js",
     "prepare:model:hikmaai": "node scripts/prepare-hikmaai-model.js",
@@ -54,5 +57,6 @@
   },
   "dependencies": {
     "@huggingface/transformers": "4.2.0"
-  }
+  },
+  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8"
 }

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -25,6 +25,7 @@ function setVersion(version, rootDir = process.cwd()) {
   const packagePath = path.join(rootDir, 'package.json');
   const lockPath = path.join(rootDir, 'package-lock.json');
   const manifestPath = path.join(rootDir, 'manifest.json');
+  const manifestFirefoxPath = path.join(rootDir, 'manifest.firefox.json');
 
   const packageJson = readJson(packagePath);
   const packageLock = readJson(lockPath);
@@ -40,6 +41,12 @@ function setVersion(version, rootDir = process.cwd()) {
   writeJson(packagePath, packageJson);
   writeJson(lockPath, packageLock);
   writeJson(manifestPath, manifest);
+
+  if (fs.existsSync(manifestFirefoxPath)) {
+    const manifestFirefox = readJson(manifestFirefoxPath);
+    manifestFirefox.version = version;
+    writeJson(manifestFirefoxPath, manifestFirefox);
+  }
 }
 
 function listReleaseFiles(rootDir) {
@@ -71,6 +78,9 @@ function checkVersion(options = {}) {
   const manifest = readJson(path.join(rootDir, 'manifest.json'));
   const changelog = fs.readFileSync(path.join(rootDir, 'CHANGELOG.md'), 'utf8');
 
+  const manifestFirefoxPath = path.join(rootDir, 'manifest.firefox.json');
+  const manifestFirefox = fs.existsSync(manifestFirefoxPath) ? readJson(manifestFirefoxPath) : null;
+
   const expectedVersion = options.expectedVersion || packageJson.version;
   const expectedTag = `v${expectedVersion}`;
   const errors = [];
@@ -87,6 +97,7 @@ function checkVersion(options = {}) {
     'package-lock.json': packageLock.version,
     'package-lock.json packages[""]': packageLock.packages?.['']?.version,
     'manifest.json': manifest.version,
+    ...(manifestFirefox ? { 'manifest.firefox.json': manifestFirefox.version } : {}),
   };
 
   for (const [label, actualVersion] of Object.entries(versions)) {

--- a/src/background/background.firefox.ts
+++ b/src/background/background.firefox.ts
@@ -1,0 +1,395 @@
+import type {
+  CancelDetectionRequest,
+  DetectPiiRequest,
+  DetectionCanceledResponse,
+  GetNerStatusRequest,
+  Message,
+  NerStatusResponse,
+  OpenOptionsPageRequest,
+  PiiResultResponse,
+  SystemCompatibilityStatusResponse,
+} from "../shared/message-types";
+import { loadSettings, saveSettings, logFeedback } from "../shared/storage";
+import { detectionOptionsFromSettings, fallbackNerStatus } from "../shared/detection-config";
+import {
+  buildSystemCheckResult,
+  loadSystemCheckResult,
+  markCriticalModalDismissed,
+  recordLoadFailure,
+  recordLocalAiEnabled,
+  recordLowMemoryAutoDisable,
+  recordLowMemoryOverride,
+  recordRecommendationDeclined,
+  recordRuntimeState,
+  recordUserLocalAiOff,
+  saveSystemCheckResult,
+  type SystemCheckResult,
+} from "../shared/system-check-storage";
+import { detectWithExternalNer, getNerStatus } from "../offscreen/detection";
+import { collectPassiveSystemSignals } from "../system-check/passive-signals";
+
+const SETTINGS_KEY = "pg_settings";
+const ACTIVE_ICON_PATHS = {
+  16: "/assets/icons/active-16.png",
+  32: "/assets/icons/active-32.png",
+  48: "/assets/icons/active-48.png",
+  128: "/assets/icons/active-128.png",
+};
+const INACTIVE_ICON_PATHS = {
+  16: "/assets/icons/inactive-16.png",
+  32: "/assets/icons/inactive-32.png",
+  48: "/assets/icons/inactive-48.png",
+  128: "/assets/icons/inactive-128.png",
+};
+
+// Active detections tracked here since we run detection in-process (no offscreen relay).
+const activeDetections = new Map<string, AbortController>();
+const canceledDetectionIds = new Set<string>();
+
+function canceledResponse(requestId: string): DetectionCanceledResponse {
+  return { type: "DETECTION_CANCELED", payload: { requestId } };
+}
+
+function rememberCanceledDetection(requestId: string): void {
+  canceledDetectionIds.add(requestId);
+  setTimeout(() => canceledDetectionIds.delete(requestId), 300000);
+}
+
+async function persistWarmupOutcome(status: NerStatusResponse["payload"]): Promise<void> {
+  if (status.state === "failed" || status.state === "unavailable") {
+    const reason = status.message ?? "Local AI failed to load.";
+    const settings = await loadSettings();
+    if (settings.nerProvider === "transformers") {
+      await saveSettings({ nerProvider: "off" });
+    }
+    await recordLoadFailure(reason);
+    return;
+  }
+  await recordRuntimeState(status.state);
+}
+
+async function applyCriticalLocalAiRecommendation(result: SystemCheckResult): Promise<SystemCheckResult> {
+  if (result.recommendation !== "auto-disable-local-ai" || result.lowMemoryOverride) {
+    return result;
+  }
+  const settings = await loadSettings();
+  if (settings.nerProvider === "transformers") {
+    await saveSettings({ nerProvider: "off" });
+    return recordLowMemoryAutoDisable(result);
+  }
+  if (settings.nerProvider === "off" && result.localAiState === "enabled") {
+    return recordUserLocalAiOff(result);
+  }
+  return result;
+}
+
+// Firefox background page is persistent — collect signals directly without offscreen.
+async function collectPassiveSignals() {
+  return collectPassiveSystemSignals();
+}
+
+async function runPassiveSystemCheck(): Promise<SystemCompatibilityStatusResponse> {
+  const previous = await loadSystemCheckResult();
+  if (previous) return { type: "SYSTEM_COMPATIBILITY_STATUS", payload: previous };
+
+  const signals = await collectPassiveSignals();
+  const result = await applyCriticalLocalAiRecommendation(buildSystemCheckResult(signals));
+  await saveSystemCheckResult(result);
+  return { type: "SYSTEM_COMPATIBILITY_STATUS", payload: result };
+}
+
+async function ensureSystemCheckResult(): Promise<SystemCompatibilityStatusResponse> {
+  const existing = await loadSystemCheckResult();
+  if (existing) return { type: "SYSTEM_COMPATIBILITY_STATUS", payload: existing };
+  return runPassiveSystemCheck();
+}
+
+async function persistResolvedNerModel(config: DetectPiiRequest["payload"]["config"]): Promise<void> {
+  if (config?.ner_provider !== "transformers" || !config.ner_model) return;
+  try {
+    const nerStatusPayload = getNerStatus(config);
+    const resolvedModel = nerStatusPayload?.model;
+    if (nerStatusPayload?.state === "ready" && resolvedModel && resolvedModel !== config.ner_model) {
+      await saveSettings({ nerModel: resolvedModel });
+    }
+  } catch {
+    // Best effort only.
+  }
+}
+
+function isBackgroundRequest(message: Message): boolean {
+  return message.type === "DETECT_PII"
+    || message.type === "CANCEL_DETECTION"
+    || message.type === "GET_NER_STATUS"
+    || message.type === "LOG_FEEDBACK"
+    || message.type === "OPEN_OPTIONS_PAGE"
+    || message.type === "GET_SYSTEM_COMPATIBILITY_STATUS"
+    || message.type === "SET_LOCAL_AI_DETECTION"
+    || message.type === "WARM_UP_LOCAL_AI"
+    || message.type === "DISMISS_CRITICAL_LOCAL_AI_MODAL"
+    || message.type === "RE_RUN_SYSTEM_CHECK"
+    || message.type === "APPLY_CRITICAL_RECOMMENDATION";
+}
+
+chrome.runtime.onMessage.addListener((message: Message, sender, sendResponse) => {
+  if (!isBackgroundRequest(message)) return false;
+
+  let responded = false;
+  const safeSendResponse = (response: unknown): void => {
+    responded = true;
+    sendResponse(response);
+  };
+
+  handleMessage(message, sender, safeSendResponse).catch((err) => {
+    console.error('[PG:background] Message handling failed:', err);
+    if (!responded) {
+      safeSendResponse({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+  return true;
+});
+
+async function handleMessage(
+  message: Message,
+  _sender: chrome.runtime.MessageSender,
+  sendResponse: (response: unknown) => void,
+): Promise<void> {
+  switch (message.type) {
+    case "DETECT_PII": {
+      const settings = await loadSettings();
+      const config = detectionOptionsFromSettings(settings, message.payload.config);
+      const { requestId, text } = message.payload;
+
+      if (canceledDetectionIds.delete(requestId)) {
+        sendResponse(canceledResponse(requestId));
+        break;
+      }
+
+      const abortController = new AbortController();
+      activeDetections.set(requestId, abortController);
+
+      try {
+        const startTime = performance.now();
+        const { spans, nerMs } = await detectWithExternalNer(text, config, abortController.signal);
+        activeDetections.delete(requestId);
+
+        if (canceledDetectionIds.delete(requestId)) {
+          sendResponse(canceledResponse(requestId));
+          break;
+        }
+
+        const totalMs = Math.round(performance.now() - startTime);
+        const response: PiiResultResponse = {
+          type: "PII_RESULT",
+          payload: { requestId, spans, timings: { totalMs, nerMs } },
+        };
+        await persistResolvedNerModel(config);
+        sendResponse(response);
+      } catch (err) {
+        activeDetections.delete(requestId);
+        if (abortController.signal.aborted) {
+          sendResponse(canceledResponse(requestId));
+          break;
+        }
+        if (canceledDetectionIds.delete(requestId)) {
+          sendResponse(canceledResponse(requestId));
+          break;
+        }
+        sendResponse({
+          type: "PII_RESULT",
+          payload: { requestId, spans: [], timings: { totalMs: 0 } },
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      break;
+    }
+
+    case "CANCEL_DETECTION": {
+      const { requestId } = (message as CancelDetectionRequest).payload;
+      rememberCanceledDetection(requestId);
+      const activeDetection = activeDetections.get(requestId);
+      if (activeDetection) {
+        activeDetection.abort();
+        activeDetections.delete(requestId);
+      }
+      sendResponse(canceledResponse(requestId));
+      break;
+    }
+
+    case "GET_NER_STATUS": {
+      const settings = await loadSettings();
+      const config = detectionOptionsFromSettings(settings, (message as GetNerStatusRequest).payload?.config);
+      sendResponse({
+        type: "NER_STATUS",
+        payload: getNerStatus(config),
+      } satisfies NerStatusResponse);
+      break;
+    }
+
+    case "LOG_FEEDBACK": {
+      await logFeedback(message.payload);
+      sendResponse({ ok: true });
+      break;
+    }
+
+    case "OPEN_OPTIONS_PAGE": {
+      const req = message as OpenOptionsPageRequest;
+      await chrome.tabs.create({ url: req.payload.url });
+      sendResponse({ ok: true });
+      break;
+    }
+
+    case "GET_SYSTEM_COMPATIBILITY_STATUS": {
+      const response = await ensureSystemCheckResult();
+      sendResponse(response);
+      break;
+    }
+
+    case "WARM_UP_LOCAL_AI": {
+      const settings = await loadSettings();
+      const config = detectionOptionsFromSettings(settings, message.payload?.config);
+      if (config.ner_provider === "off") {
+        sendResponse({
+          type: "NER_STATUS",
+          payload: fallbackNerStatus("off", "Local AI detection is turned off."),
+        } satisfies NerStatusResponse);
+        break;
+      }
+
+      try {
+        await detectWithExternalNer("Alice from Acme visited Berlin.", config);
+        const nerStatusPayload = getNerStatus(config);
+        await persistWarmupOutcome(nerStatusPayload);
+        sendResponse({ type: "NER_STATUS", payload: nerStatusPayload } satisfies NerStatusResponse);
+      } catch (err) {
+        const fallback = fallbackNerStatus(
+          config.ner_provider ?? settings.nerProvider,
+          err instanceof Error ? err.message : String(err),
+        );
+        await persistWarmupOutcome(fallback);
+        sendResponse({ type: "NER_STATUS", payload: fallback } satisfies NerStatusResponse);
+      }
+      break;
+    }
+
+    case "RE_RUN_SYSTEM_CHECK": {
+      const signals = await collectPassiveSignals();
+      const previous = await loadSystemCheckResult();
+      const rebuilt = buildSystemCheckResult(signals, Date.now(), previous);
+      await saveSystemCheckResult(rebuilt);
+
+      const settings = await loadSettings();
+      const pendingCriticalRecommendation =
+        rebuilt.recommendation === "auto-disable-local-ai"
+        && settings.nerProvider === "transformers"
+        && !rebuilt.lowMemoryOverride;
+
+      sendResponse({
+        type: "SYSTEM_COMPATIBILITY_STATUS",
+        payload: rebuilt,
+        pendingCriticalRecommendation,
+      });
+      break;
+    }
+
+    case "APPLY_CRITICAL_RECOMMENDATION": {
+      const current = await loadSystemCheckResult();
+      if (!current) {
+        sendResponse({ error: "No stored system check result" });
+        break;
+      }
+      if (message.payload.accepted) {
+        const settings = await loadSettings();
+        if (settings.nerProvider === "transformers") {
+          await saveSettings({ nerProvider: "off" });
+        }
+        const updated = await recordLowMemoryAutoDisable(current);
+        sendResponse({ type: "SYSTEM_COMPATIBILITY_STATUS", payload: updated } satisfies SystemCompatibilityStatusResponse);
+      } else {
+        const updated = await recordRecommendationDeclined();
+        sendResponse({
+          type: "SYSTEM_COMPATIBILITY_STATUS",
+          payload: updated ?? current,
+        } satisfies SystemCompatibilityStatusResponse);
+      }
+      break;
+    }
+
+    case "DISMISS_CRITICAL_LOCAL_AI_MODAL": {
+      const updated = await markCriticalModalDismissed();
+      sendResponse({ ok: true, payload: updated });
+      break;
+    }
+
+    case "SET_LOCAL_AI_DETECTION": {
+      const response = await ensureSystemCheckResult();
+      if (message.payload.enabled) {
+        await saveSettings({ nerProvider: "transformers" });
+        const updated = response.payload.tier === "critical"
+          ? await recordLowMemoryOverride()
+          : await recordLocalAiEnabled();
+        sendResponse({ type: "SYSTEM_COMPATIBILITY_STATUS", payload: updated ?? response.payload } satisfies SystemCompatibilityStatusResponse);
+      } else {
+        await saveSettings({ nerProvider: "off" });
+        const current = await loadSystemCheckResult();
+        const updated = current ? await recordUserLocalAiOff(current) : response.payload;
+        sendResponse({ type: "SYSTEM_COMPATIBILITY_STATUS", payload: updated } satisfies SystemCompatibilityStatusResponse);
+      }
+      break;
+    }
+
+    default:
+      sendResponse({ error: "Unknown message type" });
+  }
+}
+
+chrome.runtime.onInstalled.addListener(async () => {
+  const settings = await loadSettings();
+  await saveSettings(settings);
+  await ensureSystemCheckResult();
+  await updateActiveTabIcon();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  void updateActiveTabIcon();
+});
+
+chrome.tabs.onActivated.addListener(async (activeInfo) => {
+  try {
+    const tab = await chrome.tabs.get(activeInfo.tabId) ?? undefined;
+    if (tab) await updateIcon(tab);
+  } catch {
+    // Tab may not exist.
+  }
+});
+
+chrome.tabs.onUpdated.addListener(async (_tabId, _changeInfo, tab) => {
+  await updateIcon(tab);
+});
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName === "local" && changes[SETTINGS_KEY]) {
+    void updateActiveTabIcon();
+  }
+});
+
+async function updateActiveTabIcon(): Promise<void> {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true }) ?? [];
+  const [tab] = tabs;
+  if (tab) {
+    await updateIcon(tab);
+  }
+}
+
+async function updateIcon(tab: chrome.tabs.Tab): Promise<void> {
+  if (!tab || typeof tab.id !== "number") return;
+
+  const settings = await loadSettings();
+  const isMonitored = Boolean(
+    tab.url && settings.curatedUrls.some((url) => tab.url!.startsWith(url)),
+  );
+  const iconPath = settings.enabled && isMonitored ? ACTIVE_ICON_PATHS : INACTIVE_ICON_PATHS;
+
+  await chrome.action.setIcon({ path: iconPath, tabId: tab.id });
+  await chrome.action.setBadgeText({ text: "", tabId: tab.id });
+}

--- a/src/content/clipboard-interceptor-injector.ts
+++ b/src/content/clipboard-interceptor-injector.ts
@@ -1,0 +1,8 @@
+/**
+ * Firefox MV2 — runs in isolated world at document_start.
+ * Injects clipboard-interceptor-page.js into the page's main world via a
+ * <script> tag so it executes synchronously before page scripts.
+ */
+const script = document.createElement('script');
+script.src = chrome.runtime.getURL('content/clipboard-interceptor-page.js');
+document.documentElement.insertBefore(script, document.documentElement.firstChild);

--- a/src/offscreen/detection.ts
+++ b/src/offscreen/detection.ts
@@ -215,7 +215,7 @@ async function externalNerSpansFor(
       });
       return { spans, nerMs };
     } catch (err) {
-      if (signal?.aborted || err instanceof DOMException && err.name === 'AbortError') {
+      if (signal?.aborted) {
         throw err;
       }
 

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -535,7 +535,11 @@ async function defaultAssetExists(url: string): Promise<boolean> {
   }
 
   try {
-    const response = await fetch(url, { method: 'HEAD' });
+    // Firefox does not reliably return 404 for HEAD requests to missing
+    // moz-extension:// resources — use GET instead. Extension resources
+    // are served locally so the extra body data is negligible.
+    const method = url.startsWith('moz-extension://') ? 'GET' : 'HEAD';
+    const response = await fetch(url, { method });
     return response.ok;
   } catch {
     return false;

--- a/src/shared/identity-vault.ts
+++ b/src/shared/identity-vault.ts
@@ -128,7 +128,7 @@ export async function loadIdentityVault(): Promise<IdentityVaultData> {
   if (typeof chrome === 'undefined' || !chrome.storage?.local) {
     return emptyVaultData();
   }
-  const result = await chrome.storage.local.get(VAULT_STORAGE_KEY);
+  const result = await chrome.storage.local.get(VAULT_STORAGE_KEY) ?? {};
   const stored = result[VAULT_STORAGE_KEY];
   if (!stored || typeof stored !== 'object') return emptyVaultData();
 

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -9,7 +9,7 @@ const ENTITY_MAPS_KEY = 'pg_entity_maps';
 
 /** Load extension settings from chrome.storage.local. */
 export async function loadSettings(): Promise<Settings> {
-  const result = await chrome.storage.local.get(SETTINGS_KEY);
+  const result = await chrome.storage.local.get(SETTINGS_KEY) ?? {};
   return normalizeSettings(result[SETTINGS_KEY]);
 }
 
@@ -124,7 +124,7 @@ function normalizeSettings(raw: unknown): Settings {
 
 /** Append a feedback entry to the log. */
 export async function logFeedback(entry: FeedbackEntry): Promise<void> {
-  const result = await chrome.storage.local.get(FEEDBACK_KEY);
+  const result = await chrome.storage.local.get(FEEDBACK_KEY) ?? {};
   const log: FeedbackEntry[] = result[FEEDBACK_KEY] || [];
   log.push(entry);
   // Keep last 1000 entries to avoid unbounded growth
@@ -136,7 +136,7 @@ export async function logFeedback(entry: FeedbackEntry): Promise<void> {
 
 /** Get all feedback entries. */
 export async function getFeedbackLog(): Promise<FeedbackEntry[]> {
-  const result = await chrome.storage.local.get(FEEDBACK_KEY);
+  const result = await chrome.storage.local.get(FEEDBACK_KEY) ?? {};
   return result[FEEDBACK_KEY] || [];
 }
 
@@ -155,7 +155,7 @@ export async function saveEntityMap(
   conversationUrl: string,
   map: StoredEntityMap
 ): Promise<void> {
-  const result = await chrome.storage.local.get(ENTITY_MAPS_KEY);
+  const result = await chrome.storage.local.get(ENTITY_MAPS_KEY) ?? {};
   const maps: Record<string, StoredEntityMap> = result[ENTITY_MAPS_KEY] || {};
   maps[conversationUrl] = { ...maps[conversationUrl], ...map };
   await chrome.storage.local.set({ [ENTITY_MAPS_KEY]: maps });
@@ -165,7 +165,7 @@ export async function saveEntityMap(
 export async function loadEntityMap(
   conversationUrl: string
 ): Promise<StoredEntityMap> {
-  const result = await chrome.storage.local.get(ENTITY_MAPS_KEY);
+  const result = await chrome.storage.local.get(ENTITY_MAPS_KEY) ?? {};
   const maps: Record<string, StoredEntityMap> = result[ENTITY_MAPS_KEY] || {};
   return maps[conversationUrl] || {};
 }
@@ -173,7 +173,7 @@ export async function loadEntityMap(
 /** Clear entity maps for a specific conversation or all conversations. */
 export async function clearEntityMaps(conversationUrl?: string): Promise<void> {
   if (conversationUrl) {
-    const result = await chrome.storage.local.get(ENTITY_MAPS_KEY);
+    const result = await chrome.storage.local.get(ENTITY_MAPS_KEY) ?? {};
     const maps: Record<string, StoredEntityMap> = result[ENTITY_MAPS_KEY] || {};
     delete maps[conversationUrl];
     await chrome.storage.local.set({ [ENTITY_MAPS_KEY]: maps });

--- a/src/shared/system-check-storage.ts
+++ b/src/shared/system-check-storage.ts
@@ -117,7 +117,7 @@ export function normalizeSystemCheckResult(raw: unknown): SystemCheckResult | nu
 }
 
 export async function loadSystemCheckResult(): Promise<SystemCheckResult | null> {
-  const result = await chrome.storage.local.get(SYSTEM_CHECK_STORAGE_KEY);
+  const result = await chrome.storage.local.get(SYSTEM_CHECK_STORAGE_KEY) ?? {};
   return normalizeSystemCheckResult(result[SYSTEM_CHECK_STORAGE_KEY]);
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,20 +12,38 @@ module.exports = (_env = {}) => {
   const requirePreparedModel =
     process.env.NER_MODEL_ASSETS_REQUIRED === '1' || _env.requireNerModelAssets === true;
 
+  const browser = process.env.BROWSER || 'chrome';
+  const isFirefox = browser === 'firefox';
+  const outputDir = isFirefox ? 'dist-firefox' : 'dist';
+  const manifestSource = isFirefox ? 'manifest.firefox.json' : 'manifest.json';
+
+  const chromeOnlyEntries = {
+    'offscreen/offscreen': './src/offscreen/offscreen.ts',
+    'system-check/system-check-offscreen': './src/system-check/system-check-offscreen.ts',
+  };
+
   return {
     entry: {
-      'background/service-worker': './src/background/service-worker.ts',
+      ...(isFirefox
+        ? { 'background/background': './src/background/background.firefox.ts' }
+        : { 'background/service-worker': './src/background/service-worker.ts', ...chromeOnlyEntries }
+      ),
       'content/content-script': './src/content/content-script.ts',
       'content/clipboard-interceptor-page': './src/content/clipboard-interceptor-page.ts',
-      'offscreen/offscreen': './src/offscreen/offscreen.ts',
-      'system-check/system-check-offscreen': './src/system-check/system-check-offscreen.ts',
+      ...(isFirefox
+        ? { 'content/clipboard-interceptor-injector': './src/content/clipboard-interceptor-injector.ts' }
+        : {}
+      ),
       'popup/popup': './src/popup/popup.ts',
       'options/options': './src/options/options.ts',
     },
 
     output: {
-      path: path.resolve(__dirname, 'dist'),
+      path: path.resolve(__dirname, outputDir),
       filename: '[name].js',
+      // Firefox MV2 background pages can't auto-detect the public path from
+      // document.currentScript, so we pin it to the extension root explicitly.
+      publicPath: isFirefox ? '/' : 'auto',
       clean: true,
     },
 
@@ -88,7 +106,7 @@ module.exports = (_env = {}) => {
       // Copy static files to dist/
       new CopyPlugin({
         patterns: [
-          { from: 'manifest.json', to: '.' },
+          { from: manifestSource, to: 'manifest.json' },
           { from: 'src/assets', to: 'assets' },
           { from: 'src/assets/fonts', to: 'fonts' },
           { from: 'src/ui/banner/de-anon-banner.css', to: 'ui/banner/' },
@@ -116,19 +134,19 @@ module.exports = (_env = {}) => {
         chunks: ['options/options'],
       }),
 
-      // Offscreen HTML
-      new HtmlWebpackPlugin({
-        template: 'src/offscreen/offscreen.html',
-        filename: 'offscreen/offscreen.html',
-        chunks: ['offscreen/offscreen'],
-      }),
-
-      // Lightweight passive system-check offscreen HTML
-      new HtmlWebpackPlugin({
-        template: 'src/system-check/system-check-offscreen.html',
-        filename: 'system-check/system-check-offscreen.html',
-        chunks: ['system-check/system-check-offscreen'],
-      }),
+      // Offscreen HTML — Chrome only (Firefox has no offscreen API)
+      ...(!isFirefox ? [
+        new HtmlWebpackPlugin({
+          template: 'src/offscreen/offscreen.html',
+          filename: 'offscreen/offscreen.html',
+          chunks: ['offscreen/offscreen'],
+        }),
+        new HtmlWebpackPlugin({
+          template: 'src/system-check/system-check-offscreen.html',
+          filename: 'system-check/system-check-offscreen.html',
+          chunks: ['system-check/system-check-offscreen'],
+        }),
+      ] : []),
     ],
 
     // Chrome extensions require specific settings


### PR DESCRIPTION
Adds a Firefox build target alongside the existing Chrome MV3 extension.
See issue #1 

Disclaimer: I used AI (Claude) for this but I tested it. Also I do not have the RAM to run the local AI (wasm).

Key changes:
- manifest.firefox.json: MV2 manifest with persistent background page, browser_action, and flat web_accessible_resources array
- background.firefox.ts: persistent background page that runs WASM/NER in-process (no offscreen API in Firefox MV2)
- clipboard-interceptor-injector.ts: injects clipboard-interceptor-page.js via <script> tag as Firefox MV2 alternative to world:"MAIN"
- webpack.config.js: BROWSER env var selects Chrome (dist/) or Firefox (dist-firefox/) output; pins publicPath:'/' for Firefox MV2 background pages
- package.json: adds build:firefox, build:ext:firefox, dev:firefox scripts
- scripts/version.js: keeps manifest.firefox.json version in sync
- storage/identity-vault: add ?? {} guards on chrome.storage.local.get() calls that can return undefined in Firefox's chrome.* compatibility layer
- detection.ts: only rethrow AbortError when OUR signal was explicitly aborted; Firefox's network stack throws internal DOMException AbortErrors for extension resource fetch failures which must not be mistaken for user cancellations
- ner-provider.ts: use GET instead of HEAD for moz-extension:// asset checks; Firefox silently returns ok:true on HEAD for missing extension resources, causing the pipeline to attempt model loading unnecessarily