### PR TITLE
feat: improve onboarding clarity and first-run guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8238,21 +8238,6 @@
         }
       }
     },
-    "node_modules/svelte-check/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/svelte-dev-helper": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/svelte-dev-helper/-/svelte-dev-helper-1.1.9.tgz",

--- a/src/options/App.svelte
+++ b/src/options/App.svelte
@@ -8,15 +8,18 @@
 	import CancelDetectionCard from './components/CancelDetectionCard.svelte';
 	import CodeBlocksCard from './components/CodeBlocksCard.svelte';
 	import DebugSystemCheckCard from './components/DebugSystemCheckCard.svelte';
+	import OnboardingOverlay from './components/OnboardingOverlay.svelte';
 	import PublicSupportCard from './components/PublicSupportCard.svelte';
 	import SensitivityCard from './components/SensitivityCard.svelte';
 	import SystemCompatibilityCard from './components/SystemCompatibilityCard.svelte';
 	import VaultCard from './components/VaultCard.svelte';
+	import { hasSeenOnboarding, markOnboardingSeen } from '../shared/onboarding-state';
 
 	const model = createOptionsModel();
 	let allowlistCard: AllowlistCard | undefined = $state();
+	let showOnboarding = $state(false);
 
-	onMount(() => {
+	onMount(async () => {
 		const params = new URLSearchParams(window.location.search);
 		const prefill = params.get('allowlist');
 		if (prefill) {
@@ -31,8 +34,23 @@
 				document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 			});
 		}
+		const seen = await hasSeenOnboarding();
+		if (!seen) showOnboarding = true;
 	});
+
+	async function dismissOnboarding() {
+		showOnboarding = false;
+		await markOnboardingSeen();
+	}
+
+	function reopenOnboarding() {
+		showOnboarding = true;
+	}
 </script>
+
+{#if showOnboarding}
+	<OnboardingOverlay onDismiss={dismissOnboarding} />
+{/if}
 
 <div class="page">
 	<header class="page-header">
@@ -122,6 +140,12 @@
 			clearOverride={model.clearDebugSystemCheck}
 		/>
 	</main>
+
+	<footer class="page-footer">
+		<button type="button" class="onboarding-link" onclick={reopenOnboarding}>
+			Onboarding guide
+		</button>
+	</footer>
 </div>
 
 <style>
@@ -215,4 +239,24 @@
 	}
 
 	.content { padding: 0 24px; }
+
+	.page-footer {
+		padding: 12px 24px;
+		text-align: center;
+		border-top: var(--border-hairline);
+		margin-top: 8px;
+	}
+	.onboarding-link {
+		padding: 0;
+		border: 0;
+		background: transparent;
+		color: var(--color-muted);
+		font-size: 12px;
+		cursor: pointer;
+		text-decoration: underline;
+		text-underline-offset: 3px;
+	}
+	.onboarding-link:hover {
+		color: var(--color-accent);
+	}
 </style>

--- a/src/options/components/OnboardingOverlay.svelte
+++ b/src/options/components/OnboardingOverlay.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+	let { onDismiss }: { onDismiss: () => void } = $props();
+
+	const panels = [
+		{
+			id: 'download-size',
+			heading: 'Why the download is large',
+			body: `The extension bundles a named-entity recognition model (~40–80 MB of ONNX weights)
+so detection works without any network access after install. The browser caches
+these files permanently — you will not re-download them unless you uninstall and
+reinstall the extension or clear your browser profile data.`,
+		},
+		{
+			id: 'local-inference',
+			heading: 'All analysis runs in your browser',
+			body: `Text you paste into a supported page is scanned entirely inside the browser. The
+model runs in an isolated offscreen document using WebAssembly, and WebGPU when
+available. No content is ever sent to a server, and no account or internet
+connection is required for detection to work.`,
+		},
+		{
+			id: 'vault',
+			heading: 'The vault and how it stores data',
+			body: `When the vault is enabled, each detected identity is saved once in
+chrome.storage.local and reused consistently across sessions and pages — so the
+same person always becomes the same placeholder. This data lives only on this
+device and is never synced to any external service. You can export, import, or
+clear vault records at any time from the Identity vault section of these settings.`,
+		},
+		{
+			id: 'performance',
+			heading: 'What to expect from performance',
+			body: `The first scan after the browser starts triggers model loading, which may take
+several seconds. Subsequent scans within the same session reuse the loaded model
+and are substantially faster. On devices without WebGPU support, the extension
+falls back to CPU inference, which may take 5–15 seconds per scan. A memory guard
+automatically disables local inference on low-memory devices to prevent browser
+slowdowns; pattern-based detection remains active in that case.`,
+		},
+	] as const;
+
+	let openId = $state<string | null>('download-size');
+
+	function toggle(id: string) {
+		openId = openId === id ? null : id;
+	}
+</script>
+
+<div class="overlay" role="dialog" aria-modal="true" aria-label="First-run guide">
+	<div class="sheet">
+		<div class="sheet-header">
+			<h2>Getting started</h2>
+			<p class="sheet-sub">
+				This guide covers the key things to know before you start. You can reopen it any time
+				from the link at the bottom of these settings.
+			</p>
+		</div>
+
+		<div class="panels">
+			{#each panels as panel (panel.id)}
+				{@const open = openId === panel.id}
+				<div class="panel" class:open>
+					<button
+						type="button"
+						class="panel-trigger"
+						aria-expanded={open}
+						aria-controls="panel-body-{panel.id}"
+						onclick={() => toggle(panel.id)}
+					>
+						<span class="panel-heading">{panel.heading}</span>
+						<span class="chevron" aria-hidden="true">{open ? '−' : '+'}</span>
+					</button>
+					<div class="panel-body" id="panel-body-{panel.id}" hidden={!open}>
+						<p>{panel.body}</p>
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<div class="sheet-footer">
+			<button type="button" class="btn-primary" onclick={onDismiss}>
+				Continue to settings
+			</button>
+			<button type="button" class="btn-ghost" onclick={onDismiss}>
+				Skip
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 100;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgb(0 0 0 / 55%);
+		padding: 24px;
+	}
+
+	.sheet {
+		width: 100%;
+		max-width: 560px;
+		max-height: calc(100vh - 48px);
+		overflow-y: auto;
+		background: var(--color-card);
+		border-radius: var(--radius-lg);
+		border: var(--border-hairline);
+		box-shadow: 0 20px 60px rgb(0 0 0 / 30%);
+		display: flex;
+		flex-direction: column;
+	}
+
+	.sheet-header {
+		padding: 24px 24px 16px;
+		border-bottom: var(--border-hairline);
+	}
+
+	.sheet-header h2 {
+		margin: 0 0 6px;
+		font-size: 18px;
+		font-weight: 600;
+		color: var(--color-ink);
+		letter-spacing: -0.2px;
+	}
+
+	.sheet-sub {
+		margin: 0;
+		font-size: 13px;
+		color: var(--color-muted);
+		line-height: 1.5;
+	}
+
+	.panels {
+		flex: 1;
+		min-height: 0;
+	}
+
+	.panel {
+		border-bottom: var(--border-hairline);
+	}
+
+	.panel:last-child {
+		border-bottom: none;
+	}
+
+	.panel-trigger {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		padding: 14px 24px;
+		border: 0;
+		background: transparent;
+		color: var(--color-ink);
+		text-align: left;
+		cursor: pointer;
+		transition: background 100ms ease;
+	}
+
+	.panel-trigger:hover {
+		background: var(--color-surface);
+	}
+
+	.panel.open .panel-trigger {
+		background: var(--color-surface);
+	}
+
+	.panel-heading {
+		font-size: 13px;
+		font-weight: 600;
+	}
+
+	.chevron {
+		flex-shrink: 0;
+		font-size: 18px;
+		font-weight: 300;
+		line-height: 1;
+		color: var(--color-muted);
+		user-select: none;
+	}
+
+	.panel-body {
+		padding: 0 24px 16px;
+	}
+
+	.panel-body p {
+		margin: 0;
+		font-size: 13px;
+		color: var(--color-muted);
+		line-height: 1.6;
+	}
+
+	.sheet-footer {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 16px 24px;
+		border-top: var(--border-hairline);
+	}
+
+	.btn-primary {
+		padding: 8px 18px;
+		border: 0;
+		border-radius: var(--radius-md);
+		background: var(--color-accent);
+		color: #fff;
+		font-size: 13px;
+		font-weight: 600;
+		cursor: pointer;
+		transition: opacity 120ms ease;
+	}
+
+	.btn-primary:hover {
+		opacity: 0.9;
+	}
+
+	.btn-ghost {
+		padding: 8px 14px;
+		border: var(--border-hairline);
+		border-radius: var(--radius-md);
+		background: transparent;
+		color: var(--color-muted);
+		font-size: 13px;
+		cursor: pointer;
+		transition: border-color 100ms ease, color 100ms ease;
+	}
+
+	.btn-ghost:hover {
+		border-color: var(--color-accent);
+		color: var(--color-ink);
+	}
+</style>

--- a/src/options/components/SystemCompatibilityCard.svelte
+++ b/src/options/components/SystemCompatibilityCard.svelte
@@ -103,8 +103,9 @@
 				<div>
 					<label for="local-ai-toggle">Local AI detection</label>
 					<p>
-						Detects names, organizations, locations, and context-only PII. When off,
-						pattern detection remains active, but those contextual details may be missed.
+						Detects names, organizations, locations, and contextual identifiers that fixed
+						patterns alone cannot catch. Disabling this reduces coverage but also reduces
+						the memory and CPU cost of each scan.
 					</p>
 				</div>
 				<input
@@ -170,7 +171,7 @@
 						disabled={!$settings || !localAiEnabled}
 						onchange={(event) => setAutoWarmLocalAiOnActiveSupportedPage(event.currentTarget.checked)}
 					/>
-					<span>Warm Local AI on capable active supported pages</span>
+					<span>Pre-load the model when you open a supported page so the first scan is faster</span>
 				</label>
 			</div>
 		</div>
@@ -204,7 +205,7 @@
 			<button type="button" class="rerun" onclick={handleRerun} disabled={rerunInFlight}>
 				{rerunInFlight ? 'Re-running system check…' : 'Re-run system check'}
 			</button>
-			<p class="hint">Refreshes browser-reported memory and WebGPU signals. The Local AI model is not loaded.</p>
+			<p class="hint">Refreshes browser-reported memory and WebGPU capability signals. The AI model is not loaded during this check.</p>
 		</div>
 	</div>
 </article>

--- a/src/options/components/VaultCard.svelte
+++ b/src/options/components/VaultCard.svelte
@@ -92,11 +92,17 @@
 
 	<div class="body">
 		<p class="intro">
-			Each detected identity is stored once and reused everywhere. Toggle
-			<em>Synthetic</em> mode to replace placeholders like <code>[PERSON_1]</code>
-			with realistic but obviously-fake values such as <code>Jordan Park</code>,
-			which often improves LLM response quality. Pin a record to lock its
-			replacement against automatic changes.
+			Each detected identity is stored once in <code>chrome.storage.local</code> and
+			reused consistently across sessions and pages — so the same person always maps to
+			the same placeholder or synthetic value. This data lives only on this device and is
+			never sent to any external service. When the vault is off, replacements reset each
+			session and the same name may get a different placeholder each time.
+		</p>
+		<p class="intro">
+			Toggle <em>Synthetic</em> mode to replace placeholders like <code>[PERSON_1]</code>
+			with realistic but clearly-invented values such as <code>Jordan Park</code>, which
+			often improves LLM response quality. Pin a record to lock its replacement against
+			automatic changes.
 		</p>
 
 		<div class="controls">

--- a/src/popup/components/ProtectionStatusCard.svelte
+++ b/src/popup/components/ProtectionStatusCard.svelte
@@ -38,7 +38,7 @@
 {:else if $cpuFallback}
 	<div class="resource-summary" data-tone="warning" role="status">
 		<strong>Running on CPU fallback.</strong>
-		<span>WebGPU is unavailable, so local detection will be slower. Expect paste detection to take at least a couple of seconds.</span>
+		<span>WebGPU is unavailable on this device, so the model runs on CPU. Each scan may take 5–15 seconds depending on text length and hardware.</span>
 	</div>
 {/if}
 

--- a/src/shared/onboarding-state.ts
+++ b/src/shared/onboarding-state.ts
@@ -1,0 +1,32 @@
+/**
+ * Onboarding state helpers.
+ *
+ * The flag is kept in chrome.storage.local so it survives browser restarts
+ * and is never synced to any external service.
+ */
+
+const ONBOARDING_KEY = 'onboardingDismissed';
+
+/**
+ * Returns true if the user has already dismissed the onboarding overlay.
+ */
+export async function hasSeenOnboarding(): Promise<boolean> {
+  const result = await chrome.storage.local.get(ONBOARDING_KEY);
+  return result[ONBOARDING_KEY] === true;
+}
+
+/**
+ * Marks the onboarding overlay as seen so it does not appear again
+ * on subsequent visits to the Options page.
+ */
+export async function markOnboardingSeen(): Promise<void> {
+  await chrome.storage.local.set({ [ONBOARDING_KEY]: true });
+}
+
+/**
+ * Clears the dismissed flag so the onboarding overlay will appear again
+ * on the next visit. Useful for the "Onboarding guide" re-open action.
+ */
+export async function resetOnboardingSeen(): Promise<void> {
+  await chrome.storage.local.remove(ONBOARDING_KEY);
+}

--- a/src/shared/popup-resource-summary.ts
+++ b/src/shared/popup-resource-summary.ts
@@ -26,15 +26,15 @@ export function deriveResourceSummary(
     return {
       tone: 'critical',
       title: 'Local AI failed to load',
-      detail: 'Pattern detection remains active. Retry from Local AI settings.',
+      detail: 'Pattern detection remains active. Open System Compatibility in Settings to see the error and retry.',
     };
   }
 
   if (status.localAiState === 'off-low-memory-auto') {
     return {
       tone: 'critical',
-      title: 'Low memory protection mode',
-      detail: `Local AI is off because browser-reported memory is ${memoryWording(status)} (critical). Pattern detection remains active.`,
+      title: 'Low memory — local inference disabled',
+      detail: `Browser-reported memory is ${memoryWording(status)} (below the safe threshold). Local AI is off to protect browser stability. Pattern detection remains active. You can override this in System Compatibility settings.`,
     };
   }
 
@@ -42,7 +42,7 @@ export function deriveResourceSummary(
     return {
       tone: 'critical',
       title: 'Local AI enabled despite low memory',
-      detail: `Browser-reported memory is ${memoryWording(status)} (critical). Local AI may slow or freeze this browser.`,
+      detail: `Browser-reported memory is ${memoryWording(status)} (below the safe threshold). Keeping Local AI on may slow or freeze this browser. Turn it off in System Compatibility settings if you notice problems.`,
     };
   }
 

--- a/tests/popup/popup-model.test.ts
+++ b/tests/popup/popup-model.test.ts
@@ -199,7 +199,8 @@ describe('createAppModels — resource-safe popup', () => {
     await flushInit();
     const summary = get(app.protection.resourceSummary);
     expect(summary?.tone).toBe('critical');
-    expect(summary?.title).toMatch(/low memory protection mode/i);
+    expect(summary?.title).toMatch(/low memory/i);
+    expect(summary?.title).toMatch(/local inference disabled/i);
   });
 
   test('exposes a warning summary on warning tier with Local AI on', async () => {

--- a/tests/release/local-ai-release-readiness.test.ts
+++ b/tests/release/local-ai-release-readiness.test.ts
@@ -110,7 +110,7 @@ describe('Local AI release readiness: degraded states are visible', () => {
     expect(summary).toEqual({
       tone: 'critical',
       title: 'Local AI failed to load',
-      detail: 'Pattern detection remains active. Retry from Local AI settings.',
+      detail: 'Pattern detection remains active. Open System Compatibility in Settings to see the error and retry.',
     });
 
     const chipReason = deriveChipReason({ status });

--- a/tests/shared/popup-resource-summary.test.ts
+++ b/tests/shared/popup-resource-summary.test.ts
@@ -57,7 +57,7 @@ describe('deriveResourceSummary', () => {
     });
     expect(result?.tone).toBe('critical');
     expect(result?.detail).toMatch(/8 GB/);
-    expect(result?.detail).toMatch(/critical/i);
+    expect(result?.detail).toMatch(/below the safe threshold/i);
   });
 
   test('shows critical override wording', () => {


### PR DESCRIPTION
## What this changes

Adds a first-run onboarding overlay to the Options page and improves
copy across several settings surfaces. Users were left without answers
to common questions on first install: why the extension is large, how
their data stays private, what the vault does, and what performance to
expect. This addresses those gaps without adding any external calls,
telemetry, or new permissions.

## User-facing changes

- First visit to the Options page now shows an onboarding overlay with
  four panels covering download size, local-only inference, vault
  storage, and performance expectations. Dismissing it sets a flag in
  `chrome.storage.local`. A "Onboarding guide" link in the footer
  allows it to be reopened at any time.
- Local AI toggle description in System Compatibility now explains the
  coverage/performance trade-off rather than only listing what gets
  missed when it is off.
- Auto-warm checkbox label rewritten to plain language.
- Re-run system check hint clarifies that no model is loaded during the
  check.
- Identity vault intro now explicitly states data lives in
  `chrome.storage.local` only and is never sent anywhere, and explains
  what disabling the vault means for session behavior.
- Popup resource summary messages for load failure and low-memory states
  now name the settings section where users can act.
- CPU fallback timing changed from a vague phrase to a concrete range
  (5–15 seconds depending on text length and hardware).

## Privacy posture

No change. All new state is stored in `chrome.storage.local`. No
content, text, or user data is read, transmitted, or logged by any
of the new code paths. No new permissions are required.

## Tests

Three test files were updated to match the improved copy strings.
All 635 tests pass (`57 suites, 635 tests`).

## Out-of-scope confirmation

This change does not introduce telemetry, analytics, remote feedback
collection, or automatic upload of any user content.

Closes #12 