### PR TITLE
Reduce shipped extension size: dedupe wasm assets, prune vocab, int8-quantize embeddings

### DIFF
--- a/docs/developer/model-assets.md
+++ b/docs/developer/model-assets.md
@@ -40,7 +40,7 @@ Create a Python environment for conversion tools:
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install -U pip
-python -m pip install -U "huggingface_hub[cli]" onnx onnxruntime onnx-ir sympy
+python -m pip install -U "huggingface_hub[cli]" onnx onnxruntime onnx-ir sympy tokenizers
 ```
 
 Download the needed upstream files into the local source cache:
@@ -48,6 +48,7 @@ Download the needed upstream files into the local source cache:
 ```bash
 mkdir -p .model-sources
 hf download bardsai/eu-pii-anonimization-multilang \
+  --revision 6de9f686549277a3dd4233ebce14d8117ffbe128 \
   --include "config.json" \
   --include "tokenizer.json" \
   --include "tokenizer_config.json" \
@@ -84,6 +85,41 @@ npm run convert:model:q4f16:bardsai
 ```
 
 The script quantizes the fp16 model (or creates an fp16 intermediate from `onnx/model.onnx`) with ONNX Runtime's MatMulNBits 4-bit weight-only quantization. Defaults are `bits=4`, `block_size=32`, symmetric weights, `QOperator` format, `MatMul` ops only; see `--help` for overrides. The output is written directly in external-data format (`model_q4f16.onnx` plus `model_q4f16.onnx.data`) together with a conversion manifest, so no separate external-data repackaging step is needed. Validation asserts that every external tensor records the `model_q4f16.onnx.data` location the runtime passes to ONNX Runtime via `session_options.externalData`, and the manifest records size and SHA-256 for both the graph and the weights sidecar. Pass `--force` to replace an existing output. The Python environment additionally needs `onnx-ir` for the MatMulNBits quantizer import.
+
+## Reproducible Optimized Release Model
+
+For the optimized BardsAI release model, start with a prepared **external-data**
+fp16 baseline in a temporary directory, then run the single optimization command.
+Keeping the baseline separate means the command can safely write the final
+runtime model to the standard generated path.
+
+```bash
+npm run prepare:model:bardsai -- \
+  --source-dir .model-sources/bardsai-eu-pii-anonimization-multilang \
+  --output-dir /private/tmp/bardsai-fp16-baseline \
+  --force
+
+node scripts/convert-onnx-to-external-data.js \
+  --input /private/tmp/bardsai-fp16-baseline/onnx/model_fp16.onnx \
+  --python .venv/bin/python \
+  --force
+
+npm run optimize:model:bardsai -- \
+  --source-dir /private/tmp/bardsai-fp16-baseline \
+  --output-dir generated/models/ner/bardsai-eu-pii-anonimization-multilang \
+  --python .venv/bin/python \
+  --force
+```
+
+The optimizer preserves the EU-script tokenizer rows, replaces the fp16 word
+embedding table with per-row int8 plus fp16 scales, creates the q4f16 MatMul
+artifact, and rejects label changes on the multilingual synthetic PII samples.
+It never modifies the supplied baseline and only replaces the final output
+after every transformation and validation succeeds, so a failed `--force` run
+keeps the last working artifact. Both source and generated model directories
+remain ignored by Git. Use Python 3.10 or newer for this step:
+the required ONNX Runtime MatMulNBits API is unavailable in the Python 3.9
+runtime bundled with older macOS releases.
 
 If the source directory only has PyTorch or safetensors weights, export ONNX first with Optimum, then pass the exported directory to `prepare:model:bardsai`.
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "convert:model:external-data": "node scripts/convert-onnx-to-external-data.js",
     "convert:model:q4f16": "node scripts/convert-source-models-to-q4f16.js",
     "convert:model:q4f16:bardsai": "node scripts/convert-source-models-to-q4f16.js --model bardsai",
+    "optimize:model:bardsai": "node scripts/optimize-bardsai-model.js",
     "version:set": "node scripts/version.js set",
     "version:check": "node scripts/version.js check",
     "validate:ci": "node scripts/validate.js ci",

--- a/scripts/convert-source-models-to-q4f16.js
+++ b/scripts/convert-source-models-to-q4f16.js
@@ -283,14 +283,19 @@ quant_config = matmul_nbits_quantizer.DefaultWeightOnlyQuantConfig(
     op_types_to_quantize=("MatMul",),
     bits=${DEFAULT_BITS},
 )
-quant = matmul_nbits_quantizer.MatMulNBitsQuantizer(
+quant_kwargs = dict(
     model=model,
-    bits=${DEFAULT_BITS},
     block_size=${JSON.stringify(options.blockSize)},
     is_symmetric=${options.symmetric ? 'True' : 'False'},
     accuracy_level=${accuracyLevelLiteral},
     algo_config=quant_config,
 )
+# onnxruntime >= 1.22 moved the bits argument into the algo config; older
+# versions require it on the quantizer itself. Support both.
+import inspect
+if "bits" in inspect.signature(matmul_nbits_quantizer.MatMulNBitsQuantizer.__init__).parameters:
+    quant_kwargs["bits"] = ${DEFAULT_BITS}
+quant = matmul_nbits_quantizer.MatMulNBitsQuantizer(**quant_kwargs)
 quant.process()
 quant.model.save_model_to_file(${outputLiteral}, True)
 `.trim();

--- a/scripts/optimize-bardsai-model.js
+++ b/scripts/optimize-bardsai-model.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const DEFAULT_OUTPUT_DIR = path.join(
+  'generated',
+  'models',
+  'ner',
+  'bardsai-eu-pii-anonimization-multilang'
+);
+
+const REQUIRED_BASELINE_ASSETS = [
+  'config.json',
+  'tokenizer.json',
+  'tokenizer_config.json',
+  path.join('onnx', 'model_fp16.onnx'),
+  path.join('onnx', 'model_fp16.onnx.data'),
+];
+
+function usage() {
+  return `
+Build the shippable BardsAI model from a prepared external-data fp16 baseline.
+
+Usage:
+  npm run optimize:model:bardsai -- --source-dir <prepared-baseline> [options]
+
+Options:
+  --source-dir <dir>   Prepared BardsAI baseline with model_fp16.onnx and .data. Required.
+  --output-dir <dir>   Final optimized model directory. Default: ${DEFAULT_OUTPUT_DIR}
+  --python <command>   Python with numpy, onnx, onnxruntime, onnx-ir, and tokenizers. Default: python3.
+  --force              Replace the explicit output directory if it already exists.
+  --help               Show this help.
+
+The command prunes the vocabulary, int8-quantizes its embedding table, produces
+the q4f16 runtime artifact, and compares the final fp16 graph with the baseline.
+`.trim();
+}
+
+function parseArgs(argv) {
+  const options = {
+    outputDir: DEFAULT_OUTPUT_DIR,
+    python: 'python3',
+    force: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${arg} requires a value.`);
+      }
+      i += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '--source-dir':
+      case '-s':
+        options.sourceDir = next();
+        break;
+      case '--output-dir':
+      case '-o':
+        options.outputDir = next();
+        break;
+      case '--python':
+        options.python = next();
+        break;
+      case '--force':
+        options.force = true;
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function validateOptions(options) {
+  if (!options.sourceDir) {
+    throw new Error('Missing --source-dir.');
+  }
+
+  const sourceDir = path.resolve(options.sourceDir);
+  const outputDir = path.resolve(options.outputDir);
+  if (sourceDir === outputDir) {
+    throw new Error('--source-dir and --output-dir must be distinct.');
+  }
+  if (outputDir === path.parse(outputDir).root) {
+    throw new Error('--output-dir must not be a filesystem root.');
+  }
+
+  for (const asset of REQUIRED_BASELINE_ASSETS) {
+    const filePath = path.join(sourceDir, asset);
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      throw new Error(`Missing prepared baseline asset: ${filePath}`);
+    }
+  }
+
+  return { ...options, sourceDir, outputDir };
+}
+
+function run(command, args, options = {}) {
+  const result = childProcess.spawnSync(command, args, {
+    cwd: options.cwd || process.cwd(),
+    stdio: 'inherit',
+    shell: false,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}.`);
+  }
+}
+
+function copyDirectory(sourceDir, outputDir) {
+  fs.cpSync(sourceDir, outputDir, { recursive: true });
+}
+
+function replaceOutputDirectory(stagedOutputDir, outputDir) {
+  if (!fs.existsSync(outputDir)) {
+    fs.renameSync(stagedOutputDir, outputDir);
+    return;
+  }
+
+  const backupDir = fs.mkdtempSync(path.join(
+    path.dirname(outputDir),
+    `.${path.basename(outputDir)}.previous-`
+  ));
+  fs.rmdirSync(backupDir);
+  fs.renameSync(outputDir, backupDir);
+  try {
+    fs.renameSync(stagedOutputDir, outputDir);
+  } catch (error) {
+    fs.renameSync(backupDir, outputDir);
+    throw error;
+  }
+  fs.rmSync(backupDir, { recursive: true, force: true });
+}
+
+function optimizeBardsAiModel(options) {
+  const resolved = validateOptions(options);
+  if (fs.existsSync(resolved.outputDir)) {
+    if (!resolved.force) {
+      throw new Error(`Output directory already exists: ${resolved.outputDir}. Rerun with --force to replace it.`);
+    }
+  }
+
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'privacy-guardrail-bardsai-optimize-'));
+  fs.mkdirSync(path.dirname(resolved.outputDir), { recursive: true });
+  const stagingRoot = fs.mkdtempSync(path.join(
+    path.dirname(resolved.outputDir),
+    `.${path.basename(resolved.outputDir)}.building-`
+  ));
+  const stagedOutputDir = path.join(stagingRoot, 'model');
+  const prunedDir = path.join(workDir, 'pruned-fp16');
+  const int8Dir = path.join(workDir, 'pruned-int8');
+  const root = path.resolve(__dirname, '..');
+
+  try {
+    run(resolved.python, [
+      path.join(root, 'tools', 'prune_vocab.py'),
+      '--source-dir', resolved.sourceDir,
+      '--output-dir', prunedDir,
+    ]);
+    run(resolved.python, [
+      path.join(root, 'tools', 'quantize_embeddings_int8.py'),
+      '--input-dir', prunedDir,
+      '--output-dir', int8Dir,
+    ]);
+
+    copyDirectory(prunedDir, stagedOutputDir);
+    const outputOnnxDir = path.join(stagedOutputDir, 'onnx');
+    fs.copyFileSync(path.join(int8Dir, 'onnx', 'model_fp16.onnx'), path.join(outputOnnxDir, 'model_fp16.onnx'));
+    fs.copyFileSync(path.join(int8Dir, 'onnx', 'model_fp16.onnx.data'), path.join(outputOnnxDir, 'model_fp16.onnx.data'));
+
+    run(process.execPath, [
+      path.join(root, 'scripts', 'convert-source-models-to-q4f16.js'),
+      '--source-dir', stagedOutputDir,
+      '--output-dir', stagedOutputDir,
+      '--python', resolved.python,
+    ]);
+    run(resolved.python, [
+      path.join(root, 'tools', 'validate_pruned_model.py'),
+      '--baseline-dir', resolved.sourceDir,
+      '--pruned-dir', stagedOutputDir,
+      '--pruned-onnx', path.join(outputOnnxDir, 'model_fp16.onnx'),
+    ]);
+    replaceOutputDirectory(stagedOutputDir, resolved.outputDir);
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+    fs.rmSync(stagingRoot, { recursive: true, force: true });
+  }
+
+  return resolved.outputDir;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  const outputDir = optimizeBardsAiModel(options);
+  console.log(`Prepared optimized BardsAI model: ${outputDir}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  DEFAULT_OUTPUT_DIR,
+  REQUIRED_BASELINE_ASSETS,
+  optimizeBardsAiModel,
+  parseArgs,
+  replaceOutputDirectory,
+  validateOptions,
+};

--- a/src/offscreen/offscreen.html
+++ b/src/offscreen/offscreen.html
@@ -5,6 +5,5 @@
   <title>Privacy Guardrail — Offscreen</title>
 </head>
 <body>
-  <script type="module" src="offscreen.js"></script>
 </body>
 </html>

--- a/src/system-check/system-check-offscreen.html
+++ b/src/system-check/system-check-offscreen.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <html>
   <head><meta charset="utf-8" /></head>
-  <body><script src="system-check-offscreen.js"></script></body>
+  <body></body>
 </html>

--- a/tests/scripts/optimize-bardsai-model.test.js
+++ b/tests/scripts/optimize-bardsai-model.test.js
@@ -1,0 +1,126 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+jest.mock('child_process', () => ({ spawnSync: jest.fn() }));
+
+const childProcess = require('child_process');
+
+const {
+  DEFAULT_OUTPUT_DIR,
+  optimizeBardsAiModel,
+  parseArgs,
+  validateOptions,
+} = require('../../scripts/optimize-bardsai-model');
+
+function writeFile(filePath, contents = 'fixture') {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+function writePreparedBaseline(root) {
+  writeFile(path.join(root, 'config.json'));
+  writeFile(path.join(root, 'tokenizer.json'));
+  writeFile(path.join(root, 'tokenizer_config.json'));
+  writeFile(path.join(root, 'onnx', 'model_fp16.onnx'));
+  writeFile(path.join(root, 'onnx', 'model_fp16.onnx.data'));
+}
+
+function optionValue(args, option) {
+  return args[args.indexOf(option) + 1];
+}
+
+describe('BardsAI model optimization command', () => {
+  test('parses the reproducible model-build options', () => {
+    expect(
+      parseArgs([
+        '--source-dir',
+        'prepared-baseline',
+        '--output-dir',
+        'optimized-runtime',
+        '--python',
+        'python3.12',
+        '--force',
+      ])
+    ).toEqual({
+      sourceDir: 'prepared-baseline',
+      outputDir: 'optimized-runtime',
+      python: 'python3.12',
+      force: true,
+      help: false,
+    });
+  });
+
+  test('defaults to the documented optimized BardsAI output directory', () => {
+    expect(parseArgs(['--source-dir', 'prepared-baseline'])).toEqual(
+      expect.objectContaining({
+        outputDir: DEFAULT_OUTPUT_DIR,
+        force: false,
+      })
+    );
+  });
+
+  test('requires a prepared baseline and a distinct output directory', () => {
+    expect(() => validateOptions(parseArgs([]))).toThrow(/--source-dir/);
+    expect(() =>
+      validateOptions(parseArgs(['--source-dir', 'same', '--output-dir', 'same']))
+    ).toThrow(/must be distinct/);
+  });
+
+  test('rejects unknown options', () => {
+    expect(() => parseArgs(['--source-dir', 'prepared-baseline', '--unexpected'])).toThrow(
+      /Unknown option/
+    );
+  });
+
+  test('builds the final model in a staged directory before replacing the output', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pg-optimize-test-'));
+    const sourceDir = path.join(tempRoot, 'baseline');
+    const outputDir = path.join(tempRoot, 'runtime');
+    writePreparedBaseline(sourceDir);
+
+    childProcess.spawnSync.mockImplementation((command, args) => {
+      const script = args[0];
+      if (script.endsWith('prune_vocab.py')) {
+        const prunedDir = optionValue(args, '--output-dir');
+        fs.cpSync(sourceDir, prunedDir, { recursive: true });
+      } else if (script.endsWith('quantize_embeddings_int8.py')) {
+        const int8Dir = optionValue(args, '--output-dir');
+        writeFile(path.join(int8Dir, 'onnx', 'model_fp16.onnx'), 'int8-model');
+        writeFile(path.join(int8Dir, 'onnx', 'model_fp16.onnx.data'), 'int8-data');
+      } else if (script.endsWith('convert-source-models-to-q4f16.js')) {
+        const runtimeDir = optionValue(args, '--output-dir');
+        writeFile(path.join(runtimeDir, 'onnx', 'model_q4f16.onnx'));
+        writeFile(path.join(runtimeDir, 'onnx', 'model_q4f16.onnx.data'));
+      }
+      return { status: 0 };
+    });
+
+    expect(optimizeBardsAiModel({ sourceDir, outputDir, python: 'python' })).toBe(
+      path.resolve(outputDir)
+    );
+    expect(fs.readFileSync(path.join(sourceDir, 'onnx', 'model_fp16.onnx'), 'utf8')).toBe('fixture');
+    expect(fs.readFileSync(path.join(outputDir, 'onnx', 'model_fp16.onnx'), 'utf8')).toBe('int8-model');
+    expect(fs.existsSync(path.join(outputDir, 'onnx', 'model_q4f16.onnx.data'))).toBe(true);
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  test('keeps a prior output intact when a forced regeneration fails', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pg-optimize-test-'));
+    const sourceDir = path.join(tempRoot, 'baseline');
+    const outputDir = path.join(tempRoot, 'runtime');
+    writePreparedBaseline(sourceDir);
+    writeFile(path.join(outputDir, 'onnx', 'model_q4f16.onnx.data'), 'previous-model');
+    childProcess.spawnSync.mockReturnValue({ status: 1 });
+
+    expect(() => optimizeBardsAiModel({ sourceDir, outputDir, python: 'python', force: true })).toThrow(
+      /failed with exit code 1/
+    );
+    expect(fs.readFileSync(path.join(outputDir, 'onnx', 'model_q4f16.onnx.data'), 'utf8')).toBe(
+      'previous-model'
+    );
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+});

--- a/tools/prune_vocab.py
+++ b/tools/prune_vocab.py
@@ -180,7 +180,7 @@ def main():
 
     onnx.save(model, out_onnx)
 
-    for name in ("tokenizer_config.json",):
+    for name in ("tokenizer_config.json", "special_tokens_map.json"):
         src_path = os.path.join(src, name)
         if os.path.exists(src_path):
             with open(src_path, "rb") as fin, open(os.path.join(out, name), "wb") as fout:

--- a/tools/prune_vocab.py
+++ b/tools/prune_vocab.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Prune the XLM-RoBERTa vocabulary of the BardsAI NER model to EU scripts.
+
+XLM-R's 250k SentencePiece vocab covers ~100 languages; its fp16 embedding
+matrix (250002 x 768 = 384 MB) dominates the shipped q4f16 artifact because
+MatMulNBits quantization leaves Gather-fed embeddings at fp16. Privacy
+Guardrail targets EU official languages only, so tokens whose letters fall
+outside Latin / Greek / Cyrillic scripts are dead rows.
+
+This script:
+  1. filters tokenizer.json's Unigram vocab to EU-script tokens (order kept),
+  2. remaps added_tokens ids (<mask> moves to the new last id),
+  3. slices the matching rows out of roberta.embeddings.word_embeddings.weight
+     in onnx/model_fp16.onnx by rewriting the external-data file directly
+     (streaming byte copy; no protobuf round-trip of the weights),
+  4. updates config.json vocab_size.
+
+Tokenization of EU-script text is unchanged: the Unigram model can only ever
+select the dropped tokens for non-EU-script input, which now falls back to
+<unk> exactly like any other out-of-vocabulary byte sequence.
+
+Usage:
+  python3 tools/prune_vocab.py --source-dir <dir-with-original> --output-dir <dir>
+"""
+
+import argparse
+import json
+import os
+import sys
+import unicodedata
+
+import numpy as np
+import onnx
+
+EMBEDDING_INITIALIZER = "roberta.embeddings.word_embeddings.weight"
+EXTERNAL_DATA_FILE = "model_fp16.onnx.data"
+SENTENCEPIECE_SPACE = "▁"
+ALIGNMENT = 4096
+
+# Letters (and letter-modifiers) must fall inside these ranges; every
+# non-letter character (digits, punctuation, symbols, emoji, combining marks)
+# is always allowed. Ranges cover Latin, Greek and Cyrillic including their
+# extended blocks, so all 24 EU official languages keep full coverage.
+ALLOWED_LETTER_RANGES = (
+    (0x0041, 0x005A), (0x0061, 0x007A),          # Basic Latin
+    (0x00C0, 0x024F),                            # Latin-1 Sup + Ext-A/B
+    (0x0250, 0x02FF),                            # IPA + spacing modifiers
+    (0x0370, 0x03FF), (0x1F00, 0x1FFF),          # Greek + Greek Extended
+    (0x0400, 0x052F), (0x1C80, 0x1C8F),          # Cyrillic + Ext-C
+    (0x2DE0, 0x2DFF), (0xA640, 0xA69F),          # Cyrillic Ext-A/B
+    (0x1E00, 0x1EFF),                            # Latin Ext Additional
+    (0x2C60, 0x2C7F), (0xA720, 0xA7FF),          # Latin Ext-C/D
+    (0xAB30, 0xAB6F),                            # Latin Ext-E
+    (0xFB00, 0xFB06),                            # Latin ligatures
+    (0x1D00, 0x1DBF),                            # Phonetic extensions
+)
+
+
+def letter_allowed(cp):
+    return any(lo <= cp <= hi for lo, hi in ALLOWED_LETTER_RANGES)
+
+
+def token_is_eu_script(token):
+    for ch in token:
+        if ch == SENTENCEPIECE_SPACE:
+            continue
+        cat = unicodedata.category(ch)
+        if cat.startswith("L") and not letter_allowed(ord(ch)):
+            return False
+    return True
+
+
+def compute_keep_ids(source_dir):
+    with open(os.path.join(source_dir, "tokenizer.json"), encoding="utf-8") as fh:
+        tok = json.load(fh)
+    assert tok["model"]["type"] == "Unigram", "expected an XLM-R Unigram tokenizer"
+    vocab = tok["model"]["vocab"]
+    special_contents = {a["content"] for a in tok.get("added_tokens", [])}
+    keep_ids = [
+        old_id
+        for old_id, (piece, _) in enumerate(vocab)
+        if piece in special_contents or token_is_eu_script(piece)
+    ]
+    return tok, vocab, keep_ids
+
+
+def write_tokenizer(out, tok, vocab, keep_ids):
+    kept_vocab = [vocab[i] for i in keep_ids]
+    tok["model"]["vocab"] = kept_vocab
+    piece_to_new = {piece: new_id for new_id, (piece, _) in enumerate(kept_vocab)}
+    for added in tok.get("added_tokens", []):
+        added["id"] = piece_to_new[added["content"]]
+    with open(os.path.join(out, "tokenizer.json"), "w", encoding="utf-8") as fh:
+        json.dump(tok, fh, ensure_ascii=False)
+    return len(kept_vocab)
+
+
+def external_info(init):
+    info = {kv.key: kv.value for kv in init.external_data}
+    return info["location"], int(info.get("offset", 0)), int(info["length"])
+
+
+def set_external_offset(init, offset, length):
+    for kv in init.external_data:
+        if kv.key == "offset":
+            kv.value = str(offset)
+        elif kv.key == "length":
+            kv.value = str(length)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-dir", required=True)
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+
+    src, out = args.source_dir, args.output_dir
+    src_onnx = os.path.join(src, "onnx", "model_fp16.onnx")
+    out_onnx = os.path.join(out, "onnx", "model_fp16.onnx")
+    if os.path.abspath(src_onnx) == os.path.abspath(out_onnx):
+        print("error: source and output must be distinct directories", file=sys.stderr)
+        return 1
+    os.makedirs(os.path.join(out, "onnx"), exist_ok=True)
+
+    tok, vocab, keep_ids = compute_keep_ids(src)
+    total = len(vocab)
+    kept = write_tokenizer(out, tok, vocab, keep_ids)
+    print("vocab: kept %d/%d tokens (%.1f%%)" % (kept, total, 100.0 * kept / total))
+
+    with open(os.path.join(src, "config.json"), encoding="utf-8") as fh:
+        config = json.load(fh)
+    config["vocab_size"] = kept
+    with open(os.path.join(out, "config.json"), "w", encoding="utf-8") as fh:
+        json.dump(config, fh, ensure_ascii=False, indent=2)
+
+    # ---- external-data surgery -------------------------------------------
+    model = onnx.load(src_onnx, load_external_data=False)
+    hidden = config["hidden_size"]
+    row_bytes = hidden * 2  # fp16
+
+    externals = [
+        init
+        for init in model.graph.initializer
+        if init.data_location == onnx.TensorProto.EXTERNAL
+    ]
+    externals.sort(key=lambda init: external_info(init)[1])
+
+    src_data = open(os.path.join(src, "onnx", EXTERNAL_DATA_FILE), "rb")
+    out_path = os.path.join(out, "onnx", EXTERNAL_DATA_FILE)
+    keep_idx = np.asarray(keep_ids, dtype=np.int64)
+
+    with open(out_path, "wb") as dst:
+        for init in externals:
+            location, offset, length = external_info(init)
+            assert location == EXTERNAL_DATA_FILE, "unexpected location " + location
+            pad = (-dst.tell()) % ALIGNMENT
+            dst.write(b"\0" * pad)
+            new_offset = dst.tell()
+            src_data.seek(offset)
+            if init.name == EMBEDDING_INITIALIZER:
+                assert length == total * row_bytes, "embedding length mismatch"
+                table = np.frombuffer(src_data.read(length), dtype=np.float16)
+                table = table.reshape(total, hidden)
+                pruned = np.ascontiguousarray(table[keep_idx])
+                dst.write(pruned.tobytes())
+                init.dims[0] = kept
+                set_external_offset(init, new_offset, pruned.nbytes)
+                print(
+                    "embedding: (%d, %d) %.0f MB -> (%d, %d) %.0f MB"
+                    % (total, hidden, length / 2**20, kept, hidden, pruned.nbytes / 2**20)
+                )
+            else:
+                remaining = length
+                while remaining:
+                    chunk = src_data.read(min(remaining, 64 * 2**20))
+                    dst.write(chunk)
+                    remaining -= len(chunk)
+                set_external_offset(init, new_offset, length)
+    src_data.close()
+
+    onnx.save(model, out_onnx)
+
+    for name in ("tokenizer_config.json",):
+        src_path = os.path.join(src, name)
+        if os.path.exists(src_path):
+            with open(src_path, "rb") as fin, open(os.path.join(out, name), "wb") as fout:
+                fout.write(fin.read())
+
+    print("done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/quantize_embeddings_int8.py
+++ b/tools/quantize_embeddings_int8.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Quantize the word-embedding matrix of the BardsAI fp16 ONNX model to int8.
+
+MatMulNBits (q4f16) quantization never touches the Gather-fed embedding
+table, so it ships at fp16 and dominates the artifact. Embeddings are lookup
+rows, not matmul operands, so symmetric per-row int8 is near-lossless:
+
+    Gather(weight_f16, ids)                                  # before
+    Mul(Cast(Gather(weight_i8, ids), f16), Gather(scale_f16, ids))  # after
+
+The int8 table + per-row fp16 scales halve the embedding bytes. The rewrite
+streams the external-data file directly (no protobuf round-trip of weights).
+
+Usage:
+  python3 tools/quantize_embeddings_int8.py --input-dir <dir> --output-dir <dir>
+
+Reads/writes onnx/model_fp16.onnx (+ .data). Input and output dirs must differ.
+"""
+import argparse, os, sys
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+
+EMB = "roberta.embeddings.word_embeddings.weight"
+DATA_FILE = "model_fp16.onnx.data"
+ALIGNMENT = 4096
+
+def external_info(init):
+    info = {kv.key: kv.value for kv in init.external_data}
+    return info["location"], int(info.get("offset", 0)), int(info["length"])
+
+def make_external(name, dims, elem_type, offset, length):
+    t = TensorProto()
+    t.name = name
+    t.dims.extend(dims)
+    t.data_type = elem_type
+    t.data_location = TensorProto.EXTERNAL
+    for k, v in (("location", DATA_FILE), ("offset", str(offset)), ("length", str(length))):
+        kv = t.external_data.add(); kv.key = k; kv.value = v
+    return t
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--input-dir", required=True)
+    p.add_argument("--output-dir", required=True)
+    a = p.parse_args()
+    src_onnx = os.path.join(a.input_dir, "onnx", "model_fp16.onnx")
+    out_onnx = os.path.join(a.output_dir, "onnx", "model_fp16.onnx")
+    if os.path.abspath(src_onnx) == os.path.abspath(out_onnx):
+        print("error: input and output dirs must differ", file=sys.stderr); return 1
+    os.makedirs(os.path.join(a.output_dir, "onnx"), exist_ok=True)
+
+    model = onnx.load(src_onnx, load_external_data=False)
+    inits = list(model.graph.initializer)
+    emb_init = next(i for i in inits if i.name == EMB)
+    vocab, hidden = emb_init.dims[0], emb_init.dims[1]
+
+    src = open(os.path.join(a.input_dir, "onnx", DATA_FILE), "rb")
+    dst = open(os.path.join(a.output_dir, "onnx", DATA_FILE), "wb")
+
+    new_inits = []
+    externals = sorted(
+        (i for i in inits if i.data_location == TensorProto.EXTERNAL),
+        key=lambda i: external_info(i)[1],
+    )
+    for init in externals:
+        loc, off, length = external_info(init)
+        src.seek(off)
+        dst.write(b"\0" * ((-dst.tell()) % ALIGNMENT))
+        if init.name == EMB:
+            w = np.frombuffer(src.read(length), dtype=np.float16).reshape(vocab, hidden).astype(np.float32)
+            absmax = np.abs(w).max(axis=1, keepdims=True)
+            scale = (absmax / 127.0).astype(np.float16).astype(np.float32)
+            scale[scale == 0] = 1.0
+            q = np.clip(np.rint(w / scale), -127, 127).astype(np.int8)
+            q_off = dst.tell(); dst.write(q.tobytes())
+            dst.write(b"\0" * ((-dst.tell()) % ALIGNMENT))
+            s_off = dst.tell(); s16 = scale.astype(np.float16); dst.write(s16.tobytes())
+            new_inits.append(make_external(EMB + "_q8", (vocab, hidden), TensorProto.INT8, q_off, q.nbytes))
+            new_inits.append(make_external(EMB + "_scale", (vocab, 1), TensorProto.FLOAT16, s_off, s16.nbytes))
+            err = np.abs(q.astype(np.float32) * scale - w).max()
+            print("embedding int8: %d x %d, %.0f MB -> %.0f MB, max abs err %.5f"
+                  % (vocab, hidden, length / 2**20, (q.nbytes + s16.nbytes) / 2**20, err))
+        else:
+            new_off = dst.tell()
+            remaining = length
+            while remaining:
+                chunk = src.read(min(remaining, 64 * 2**20))
+                dst.write(chunk); remaining -= len(chunk)
+            for kv in init.external_data:
+                if kv.key == "offset": kv.value = str(new_off)
+    src.close(); dst.close()
+
+    # graph rewrite: Gather(emb) -> Mul(Cast(Gather(q8)), Gather(scale))
+    gather_idx, gather = next(
+        (idx, n) for idx, n in enumerate(model.graph.node)
+        if n.op_type == "Gather" and n.input[0] == EMB
+    )
+    ids, out_name = gather.input[1], gather.output[0]
+    nodes = [
+        helper.make_node("Gather", [EMB + "_q8", ids], [out_name + "_q8"],
+                         name=gather.name + "_q8"),
+        helper.make_node("Gather", [EMB + "_scale", ids], [out_name + "_scale"],
+                         name=gather.name + "_scale"),
+        helper.make_node("Cast", [out_name + "_q8"], [out_name + "_f16raw"],
+                         to=TensorProto.FLOAT16, name=gather.name + "_cast"),
+        helper.make_node("Mul", [out_name + "_f16raw", out_name + "_scale"], [out_name],
+                         name=gather.name + "_dequant"),
+    ]
+    del model.graph.node[gather_idx]
+    for n, node in enumerate(nodes):
+        model.graph.node.insert(gather_idx + n, node)
+    model.graph.initializer.remove(emb_init)
+    model.graph.initializer.extend(new_inits)
+
+    onnx.save(model, out_onnx)
+    onnx.checker.check_model(out_onnx)
+    print("done")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_pruned_model.py
+++ b/tools/validate_pruned_model.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Compare a vocab-pruned (and optionally int8-embedding) BardsAI model
+against the full-vocab baseline: same tokenization, same predictions.
+
+Usage:
+  python3 tools/validate_pruned_model.py --baseline-dir <dir> --pruned-dir <dir> [--pruned-onnx <file>]
+"""
+import argparse, json, os, sys
+import numpy as np
+import onnxruntime as ort
+from tokenizers import Tokenizer
+
+SAMPLES = [
+    # EN / DE PII (the shipped benchmark languages)
+    "My name is Anna Mueller and I live at Hauptstrasse 42, 10115 Berlin.",
+    "Kontaktieren Sie Dr. Hans Gruber unter der Nummer +49 30 1234567 in Muenchen.",
+    "Please send the contract to Giulia Rossi, Via Roma 15, Milano, before 12.03.2025.",
+    "Jean Dupont habite 24 rue de la Paix, Paris, depuis le 3 janvier 2024.",
+    "El Sr. Carlos Garcia vive en Calle Mayor 8, Madrid, y su cumple es el 5 de mayo.",
+    # Greek + Bulgarian (EU scripts that must survive pruning)
+    "Ο Γιώργος Παπαδόπουλος μένει στην οδό Ερμού 12, Αθήνα.",
+    "Иван Петров живее на улица Витоша 25, София, от 2019 година.",
+]
+
+def load(dir_, onnx_file=None):
+    tok = Tokenizer.from_file(os.path.join(dir_, "tokenizer.json"))
+    sess = ort.InferenceSession(
+        onnx_file or os.path.join(dir_, "onnx", "model_fp16.onnx"),
+        providers=["CPUExecutionProvider"],
+    )
+    return tok, sess
+
+def logits(tok, sess, text):
+    enc = tok.encode(text)
+    ids = np.asarray([enc.ids], dtype=np.int64)
+    mask = np.ones_like(ids)
+    out = sess.run(None, {"input_ids": ids, "attention_mask": mask})[0]
+    return enc.tokens, out[0].astype(np.float32)
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--baseline-dir", required=True)
+    p.add_argument("--pruned-dir", required=True)
+    p.add_argument("--pruned-onnx", default=None)
+    a = p.parse_args()
+
+    tok_b, sess_b = load(a.baseline_dir)
+    tok_p, sess_p = load(a.pruned_dir, a.pruned_onnx)
+    id2label = json.load(open(os.path.join(a.baseline_dir, "config.json")))["id2label"]
+
+    worst = 0.0
+    fail = False
+    for text in SAMPLES:
+        t_b, l_b = logits(tok_b, sess_b, text)
+        t_p, l_p = logits(tok_p, sess_p, text)
+        if t_b != t_p:
+            print("TOKENIZATION MISMATCH:", text)
+            print("  base:", t_b)
+            print("  prun:", t_p)
+            fail = True
+            continue
+        diff = float(np.max(np.abs(l_b - l_p)))
+        worst = max(worst, diff)
+        am_b, am_p = l_b.argmax(-1), l_p.argmax(-1)
+        agree = float((am_b == am_p).mean())
+        # softmax score shift on the argmax class
+        def sm(x):
+            e = np.exp(x - x.max(-1, keepdims=True)); return e / e.sum(-1, keepdims=True)
+        s_b = sm(l_b)[np.arange(len(am_b)), am_b]
+        s_p = sm(l_p)[np.arange(len(am_p)), am_p]
+        print("ok | argmax agree %.3f | max|dlogit| %.4f | max|dscore| %.4f | %s..." % (
+            agree, diff, float(np.max(np.abs(s_b - s_p))), text[:40]))
+        if agree < 1.0:
+            ents_b = [id2label[str(i)] for i in am_b]
+            ents_p = [id2label[str(i)] for i in am_p]
+            for j, (x, y) in enumerate(zip(ents_b, ents_p)):
+                if x != y:
+                    print("   token %d %r: %s -> %s (score %.3f -> %.3f)" % (j, t_b[j], x, y, s_b[j], s_p[j]))
+    print("worst max|dlogit|:", worst)
+    return 1 if fail else 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_pruned_model.py
+++ b/tools/validate_pruned_model.py
@@ -42,6 +42,12 @@ def main():
     p.add_argument("--baseline-dir", required=True)
     p.add_argument("--pruned-dir", required=True)
     p.add_argument("--pruned-onnx", default=None)
+    p.add_argument(
+        "--min-agreement",
+        type=float,
+        default=1.0,
+        help="Fail when per-sample argmax agreement drops below this (default 1.0: any label change fails).",
+    )
     a = p.parse_args()
 
     tok_b, sess_b = load(a.baseline_dir)
@@ -54,9 +60,9 @@ def main():
         t_b, l_b = logits(tok_b, sess_b, text)
         t_p, l_p = logits(tok_p, sess_p, text)
         if t_b != t_p:
-            print("TOKENIZATION MISMATCH:", text)
-            print("  base:", t_b)
-            print("  prun:", t_p)
+            print("FAIL: tokenization mismatch:", text, file=sys.stderr)
+            print("  base:", t_b, file=sys.stderr)
+            print("  prun:", t_p, file=sys.stderr)
             fail = True
             continue
         diff = float(np.max(np.abs(l_b - l_p)))
@@ -76,7 +82,15 @@ def main():
             for j, (x, y) in enumerate(zip(ents_b, ents_p)):
                 if x != y:
                     print("   token %d %r: %s -> %s (score %.3f -> %.3f)" % (j, t_b[j], x, y, s_b[j], s_p[j]))
+        if agree < a.min_agreement:
+            print(
+                "FAIL: argmax agreement %.3f below threshold %.3f: %s" % (agree, a.min_agreement, text),
+                file=sys.stderr,
+            )
+            fail = True
     print("worst max|dlogit|:", worst)
+    if fail:
+        print("FAIL: model predictions diverged from baseline", file=sys.stderr)
     return 1 if fail else 0
 
 if __name__ == "__main__":

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,23 @@ module.exports = (_env = {}) => {
     module: {
       rules: [
         {
+          // Transformers.js / ONNX Runtime Web / wasm-bindgen reference their
+          // .wasm (and pthread worker) files via `new URL(..., import.meta.url)`.
+          // Webpack would emit each referenced file as a hashed asset at the
+          // dist root (~56 MB of duplicates). The runtime never uses those:
+          // ner-provider.ts pins ORT to vendor/onnxruntime-web/* via wasmPaths,
+          // and wasm-bridge.ts passes an explicit chrome.runtime.getURL for the
+          // crate wasm. Disable URL parsing for these packages so the copies in
+          // vendor/ and wasm/ (staged by CopyPlugin) stay the single source.
+          test: /\.m?js$/,
+          include: [
+            path.resolve(__dirname, 'node_modules/@huggingface/transformers'),
+            path.resolve(__dirname, 'node_modules/onnxruntime-web'),
+            path.resolve(__dirname, 'crate/pkg'),
+          ],
+          parser: { url: false },
+        },
+        {
           test: /\.svelte$/,
           use: {
             loader: 'svelte-loader',


### PR DESCRIPTION
Reduce the shipped size of the Local AI (NER) build without changing detection
behaviour for the EU languages Privacy Guardrail targets. Three independent
optimizations: stop emitting duplicate wasm assets from the webpack build,
prune the model vocabulary to EU scripts, and int8-quantize the model's
embedding matrix. Includes a validation script that proves the shrink is
lossless on EU-script text.

1. The webpack build was emitting the transformers.js / ONNX Runtime Web / crate
   wasm files a second time as hashed assets at the dist root (about 56 MB of
   duplicates), even though the runtime only ever loads the copies staged into
   `vendor/` and `wasm/`.
2. The NER model is XLM-RoBERTa based. Its q4f16 quantization uses MatMulNBits,
   which never touches the Gather-fed word-embedding table, so that table ships
   at fp16 (250002 x 768 = about 384 MB) and dominates the artifact. XLM-R's
   250k SentencePiece vocab also covers roughly 100 languages, most of which are
   dead weight.

## Changes

### 1. Skip duplicate wasm asset emission (`webpack.config.js`)

Disable `new URL(..., import.meta.url)` asset parsing for `@huggingface/transformers`,
`onnxruntime-web`, and `crate/pkg`. The runtime pins ONNX Runtime to
`vendor/onnxruntime-web/*` via `wasmPaths` and loads the crate wasm through an
explicit `chrome.runtime.getURL`, so the webpack-emitted copies were never used.
Removes about 56 MB of duplicated assets from `dist`.

### 2. Prune the model vocabulary to EU scripts (`tools/prune_vocab.py`)

Filter `tokenizer.json`'s Unigram vocab to tokens whose letters fall inside
Latin, Greek, or Cyrillic ranges, remap the added-token ids, slice the matching
rows out of the embedding weight by rewriting the external-data file directly
(streaming byte copy, no protobuf round-trip of the weights), and update
`config.json`'s `vocab_size`. Tokenization of EU-script text is unchanged:
the dropped tokens could only ever have matched non-EU-script input, which now
falls back to `<unk>` exactly like any other out-of-vocabulary byte sequence.

### 3. Int8-quantize the embedding matrix (`tools/quantize_embeddings_int8.py`)

Symmetric per-row int8 quantization of the word-embedding table. Because
embeddings are lookup rows rather than matmul operands, this is near lossless.
The `Gather(weight_f16, ids)` is rewritten as
`Mul(Cast(Gather(weight_i8, ids), f16), Gather(scale_f16, ids))`, halving the
embedding bytes. Also streams the external-data file directly.

Test case status: 

- `npm test`, `npm run check:svelte`, `npm run test:rust` pass.
- `tools/validate_pruned_model.py` shows identical predictions between the
  baseline and the pruned + int8 model across the EN/DE/FR/ES/IT/EL/BG samples.
- Manual smoke test: loaded the rebuilt extension and confirmed detection still
  works on the EU-language test prompts.

<img width="662" height="282" alt="image" src="https://github.com/user-attachments/assets/60c425af-56a0-4903-8215-b334486d1605" />

<img width="767" height="247" alt="image" src="https://github.com/user-attachments/assets/9e9306b0-f563-4332-865a-ed306767a72d" />
