### PR TITLE
Rename Intercept clipboard to Intercept copy, document clipboard access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The project follows public beta release notes for `0.x` versions.
 
 ## Unreleased
 
+- Renamed the **Intercept clipboard** setting to **Intercept copy**. It only ever governed the offer to restore original values when you copy text out of a chat; it never affected the review of text you paste, which follows the master protection toggle. The old name suggested it covered both directions.
+- The privacy policy now has a Clipboard Access section spelling out when the extension reads or writes clipboard content, that it holds no clipboard permissions, and that it runs only on the supported chat sites.
+
 ## [0.4.1] - Public Beta
 
 - Reduced the packaged extension from about 408 MB to about 167 MB by shipping the optimized Local AI model. Version 0.4.0 added the tooling for this but still packaged the unoptimized model assets.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -141,8 +141,9 @@ copy button works.
 Reviewing what you paste is controlled by the master protection toggle. With master protection
 switched off, the extension no longer reviews what you paste, no longer inspects what you copy,
 and stores nothing further. The page-world observer described above remains installed on the
-supported sites, because it is part of the page scripts injected there, but nothing acts on what
-it reports and no clipboard text is inspected, stored, or sent anywhere.
+supported sites, because it is part of the page scripts injected there, but nothing in the
+extension acts on what it reports. What it reports travels only as a message within the page you
+are already on; the text is not inspected, not stored, and never leaves your browser.
 
 In every case, clipboard content is processed **locally in your browser**. As stated in §5, it is
 never transmitted to DFKI.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -118,11 +118,16 @@ perform yourself:
   supported site the extension inspects the copied text for placeholders it inserted earlier, so
   that it can offer to restore the original values. It takes that text from the copy event or
   from the current page selection. To catch copies triggered by the website's own buttons, a
-  small script on those sites also observes clipboard writes made by the page; when the setting
-  is disabled, the extension discards those notifications without inspecting the text.
+  small script on those sites also observes clipboard writes that the site itself makes and
+  reports them to the extension. That script is part of the page scripts injected on those sites
+  and is always present there; when interception is off, the extension discards what it reports
+  without inspecting the text.
 
-The extension does not poll or monitor the clipboard between these events, and it retains no
-clipboard content once the action is complete, apart from the local mappings described in §9.
+The extension does not poll or monitor the clipboard between these events. What it keeps
+afterwards is limited to the local storage described in §9: the placeholder ↔ original-value
+mappings needed for restoration, and, if you correct a detection while reviewing, that item's
+text together with up to 20 characters of the surrounding text on either side, kept in the local
+feedback log. Both stay on your device.
 
 **When clipboard text is written.** The extension writes to the clipboard only when you click a
 button it has put on the page, and only with text in which placeholders have been restored to
@@ -134,7 +139,10 @@ copy button works.
 
 **How to switch it off.** The copy-side behavior is controlled by the **Intercept copy** setting.
 Reviewing what you paste is controlled by the master protection toggle. With master protection
-switched off, the extension reads no clipboard text at all.
+switched off, the extension no longer reviews what you paste, no longer inspects what you copy,
+and stores nothing further. The page-world observer described above remains installed on the
+supported sites, because it is part of the page scripts injected there, but nothing acts on what
+it reports and no clipboard text is inspected, stored, or sent anywhere.
 
 In every case, clipboard content is processed **locally in your browser**. As stated in §5, it is
 never transmitted to DFKI.
@@ -172,7 +180,7 @@ you use:
 | `pg_settings` | Your preferences (categories, sensitivity, replacement mode, theme, Local AI options, allow/block lists) | To apply your chosen configuration |
 | `pg_entity_maps` | Placeholder ↔ original-value mappings, keyed by conversation URL | To restore original values you replaced |
 | `pg_identity_vault` | Identity vault entries (stable replacements for recurring identities) | To produce consistent replacements across pastes |
-| `pg_feedback` | Local correction/feedback records (capped at the last 1000 entries) | To improve your local experience; never uploaded |
+| `pg_feedback` | Local correction/feedback records: the corrected item's text, a short excerpt of the text around it, the detected and corrected category, and a timestamp (capped at the last 1000 entries) | To improve your local experience; never uploaded |
 | `pg_system_check` | Result of the local system/compatibility check | To show whether Local AI can run on your device |
 
 **Where it is stored:** locally in your browser profile, on your device. It is **not** collected

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -90,7 +90,56 @@ Detection runs in the browser using local deterministic recognizers and, where a
 local AI/NER model packaged with the extension. Pasted text is **not** sent to any remote
 inference service by the extension.
 
-## 6. AI Services (ChatGPT, Claude, Gemini)
+## 6. Clipboard Access
+
+Because the extension works on text you copy and paste, this section describes precisely when
+and how it accesses clipboard content.
+
+**No clipboard permissions.** The extension's manifest requests neither the `clipboardRead` nor
+the `clipboardWrite` browser permission. Those permissions are what would allow an extension to
+read the clipboard's contents on demand. Without them, the extension only ever sees clipboard
+text that the browser itself hands to the page during a copy or paste you perform, and only
+writes to the clipboard when you click one of its buttons (see below). It cannot read your
+clipboard in the background, on a schedule, or while you are on any other website.
+
+**Where it runs.** The extension's page scripts are injected **only** on the supported chat sites
+listed in §7 (`chatgpt.com`, `chat.openai.com`, `claude.ai`, `gemini.google.com`). On every other
+website, no extension code runs at all and no clipboard content is accessible to it.
+
+**When clipboard text is read.** On the supported sites only, and only as part of an action you
+perform yourself:
+
+- **When you paste.** If you paste into the chat input field of a supported site, the extension
+  reads the pasted text from the paste event itself (`ClipboardEvent.clipboardData`), which the
+  browser hands to the page for that single event. Pastes into other fields on the page are
+  ignored, as is pasted text shorter than 10 characters. The text is then processed locally for
+  detection and presented to you for review.
+- **When you copy.** If the **Intercept copy** setting is enabled, then when you copy text on a
+  supported site the extension inspects the copied text for placeholders it inserted earlier, so
+  that it can offer to restore the original values. It takes that text from the copy event or
+  from the current page selection. To catch copies triggered by the website's own buttons, a
+  small script on those sites also observes clipboard writes made by the page; when the setting
+  is disabled, the extension discards those notifications without inspecting the text.
+
+The extension does not poll or monitor the clipboard between these events, and it retains no
+clipboard content once the action is complete, apart from the local mappings described in §9.
+
+**When clipboard text is written.** The extension writes to the clipboard only when you click a
+button it has put on the page, and only with text in which placeholders have been restored to
+their original values. There are two such buttons: **Replace with originals** in the notification
+shown after you copy, and **Copy** in the banner above a response that contains restored values.
+If you do not click either, nothing is written. These writes require no clipboard permission
+because they happen in the page in direct response to your click, in the same way a website's own
+copy button works.
+
+**How to switch it off.** The copy-side behavior is controlled by the **Intercept copy** setting.
+Reviewing what you paste is controlled by the master protection toggle. With master protection
+switched off, the extension reads no clipboard text at all.
+
+In every case, clipboard content is processed **locally in your browser**. As stated in §5, it is
+never transmitted to DFKI.
+
+## 7. AI Services (ChatGPT, Claude, Gemini)
 
 The extension supports use alongside third-party AI chat services, currently:
 
@@ -105,14 +154,14 @@ controller**. The extension does not send anything to these providers on your be
 helps you review text beforehand. Please consult each provider's privacy policy for how it
 processes the data you submit.
 
-## 7. Third-Country Transfers
+## 8. Third-Country Transfers
 
 The extension itself causes **no** transfer of personal data to third countries; nothing is
 transmitted off your device by the extension. However, if you choose to submit text to an AI
-service (see §6), that provider may process your submission in a third country under its own
+service (see §7), that provider may process your submission in a third country under its own
 terms. Any such transfer is governed by the provider, not by DFKI or this extension.
 
-## 8. Local Storage, Retention, and Deletion
+## 9. Local Storage, Retention, and Deletion
 
 The extension stores state in your browser's local extension storage (`chrome.storage.local`),
 on your end device only. The following keys may be stored, each only as needed for the function
@@ -149,21 +198,21 @@ server-side copy. The feedback log is additionally capped at the most recent 100
 **On uninstall or browser-profile deletion:** Chrome removes the extension's
 `chrome.storage.local` data, so all of the above is deleted by the browser.
 
-## 9. Special Categories of Data (Art. 9 GDPR)
+## 10. Special Categories of Data (Art. 9 GDPR)
 
 Depending on the text you choose to process, the extension may touch **special categories of
 personal data** (Art. 9 GDPR) — for example data revealing health, religion, or similar. Any
 such data is **processed locally on your device only** and is **not transmitted to DFKI**. You
 decide what text to process and what to send onward to an AI service.
 
-## 10. Automated Decision-Making / Profiling
+## 11. Automated Decision-Making / Profiling
 
 The extension does **not** carry out automated decision-making that produces legal effects or
 similarly significantly affects you within the meaning of Art. 22 GDPR. Detection is **assistive
 scoring** that surfaces suggestions for your review; it does not make decisions about a data
 subject. The extension does not create profiles of users.
 
-## 11. Your Rights
+## 12. Your Rights
 
 Under the GDPR you have the right to:
 
@@ -175,17 +224,17 @@ Under the GDPR you have the right to:
 - **data portability** (Art. 20).
 
 Because data processed by the extension stays on your device and DFKI holds none of it, you can
-exercise most of these rights directly by viewing, editing, or deleting your local data (see §8).
+exercise most of these rights directly by viewing, editing, or deleting your local data (see §9).
 For any request concerning DFKI as controller, contact the addresses in §1 and §2.
 
 You also have the right to **lodge a complaint with a supervisory authority** (Art. 77 GDPR), in
 particular in the EU member state of your residence, workplace, or the place of the alleged
 infringement.
 
-## 12. Diagnostics & Training
+## 13. Diagnostics & Training
 
 User content and local feedback logs are **not used for training** by this project. The local
-feedback log (§8) stays on your device and is never uploaded.
+feedback log (§9) stays on your device and is never uploaded.
 
 The only exception is when **you deliberately create and submit a sanitized sample outside the
 extension** (for example, attaching a synthetic example to a report). That is your own,
@@ -194,7 +243,7 @@ deliberate action.
 Any future diagnostic feature will be **described and assessed separately before it is
 introduced**. This policy does not pre-authorize any future diagnostic data flow.
 
-## 13. Public Support / GitHub Issues
+## 14. Public Support / GitHub Issues
 
 Public support is handled via **GitHub Issues, which are public**. Anything you post there is
 visible to anyone.
@@ -203,18 +252,18 @@ visible to anyone.
 screenshots containing real data, secrets, or other sensitive content in GitHub Issues. Keep all
 examples **synthetic or sanitized**.
 
-## 14. Confidential Reporting
+## 15. Confidential Reporting
 
 For sensitive security or privacy reports, contact **pii@dfki.de** directly. Do not use public
 GitHub Issues for sensitive reports. See [SECURITY.md](SECURITY.md) for what to include.
 
-## 15. Limits of Detection
+## 16. Limits of Detection
 
 Privacy Guardrail is **assistive only**. It does **not guarantee** complete detection, marking,
 or removal of personal or sensitive data, and it is **not a compliance product**. Detection can
 miss content or mis-flag content. Always review text yourself before sending it to any AI service.
 
-## 16. Impressum
+## 17. Impressum
 
 For the full legal notice (provider identification under § 5 DDG), see the
 [Impressum](IMPRESSUM.md).

--- a/src/popup/components/SettingsTab.svelte
+++ b/src/popup/components/SettingsTab.svelte
@@ -84,7 +84,7 @@
 
 	<article class="card">
 		<div class="head"><span>Behavior</span></div>
-		<div class="row"><div><div class="row-label">Intercept clipboard</div><div class="row-meta">Offer to restore copied replaced items</div></div><Toggle size="sm" checked={$clipboardInterceptEnabled} onchange={(checked) => setClipboardInterceptEnabled(checked)} label="Intercept clipboard" /></div>
+		<div class="row"><div><div class="row-label">Intercept copy</div><div class="row-meta">Offer to restore originals when you copy replaced text. Paste review follows the master protection toggle.</div></div><Toggle size="sm" checked={$clipboardInterceptEnabled} onchange={(checked) => setClipboardInterceptEnabled(checked)} label="Intercept copy" /></div>
 		<div class="divider"></div>
 		<div class="row"><div><div class="row-label">Debug mode</div><div class="row-meta">Verbose logging in console</div></div><Toggle size="sm" checked={$debug} onchange={(checked) => setDebug(checked)} label="Debug mode" /></div>
 	</article>


### PR DESCRIPTION
Closes #28.

The reporter disabled **Intercept clipboard** and found that pasting still triggered the review
prompt. The setting is not broken: it gates only the copy-side toast that offers to restore
original values (`clipboardInterceptEnabled`), while paste review is gated by `settings.enabled`
alone. The name implies it covers both directions, which is a fair reading and the actual defect.

## Changes

- **`SettingsTab.svelte`** — the row is now **Intercept copy**, and its description says that paste
  review follows the master protection toggle. The stored key stays `clipboardInterceptEnabled`,
  so no migration is needed.
- **`PRIVACY.md`** — new §6 "Clipboard Access". The policy previously mentioned the clipboard once,
  only to say nothing is uploaded, which is the second half of the issue. The new section covers
  the absent `clipboardRead`/`clipboardWrite` permissions and what they would actually gate, the
  four sites the content scripts run on, the read paths (paste event, copy event or selection,
  page-initiated writes), the two write paths, and how to switch each off. Sections 6–16 are
  renumbered to 7–17 and the three internal `§` cross-references retargeted; the statute
  references (`§ 25 TDDDG`, `§ 5 DDG`) are untouched.
- **`CHANGELOG.md`** — two entries under Unreleased.

## Notes

Writing to the clipboard needs no manifest permission here: both writes happen in the page from a
content script in direct response to a click on a button the extension rendered, the same way a
site's own copy button works. The policy says so explicitly, since "no clipboard permissions" and
"the extension writes to your clipboard" otherwise read as a contradiction.

There is no separate control for paste review on its own. If that turns out to be wanted, it is
worth a follow-up issue rather than widening this change.

## Verification

`check:svelte`, `check:privacy-boundary`, `check:permissions`, and the test files touching these
paths (`tests/shared/project-links.test.ts`, `tests/shared/storage.test.ts`) all pass.