### PR TITLE
Recognize ChatGPT's signed-out composer and paste into it correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The project follows public beta release notes for `0.x` versions.
 
 - Fixed Privacy Guardrail not recognizing the message box on ChatGPT when signed out, so no review was offered before pasting. That ChatGPT layout renders the message box as a plain text field instead of the rich editor the extension was built against. Both layouts are now recognized, and pasting keeps the cursor where you left it in either.
 - Fixed the de-anonymization banner not appearing on ChatGPT replies in that same layout.
+- Privacy Guardrail now tells you when it has switched itself off. If it fails to start on a page, pastes are no longer reviewed for the rest of that page's visit, and it previously gave no sign of this at all — so you could keep pasting while believing you were covered. It now shows a warning on the page and asks you to reload.
 - Renamed the **Intercept clipboard** setting to **Intercept copy**. It only ever governed the offer to restore original values when you copy text out of a chat; it never affected the review of text you paste, which follows the master protection toggle. The old name suggested it covered both directions.
 - The privacy policy now has a Clipboard Access section spelling out when the extension reads or writes clipboard content, that it holds no clipboard permissions, and that it runs only on the supported chat sites.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows public beta release notes for `0.x` versions.
 
 ## Unreleased
 
+- Fixed Privacy Guardrail not recognizing the message box on ChatGPT when signed out, so no review was offered before pasting. That ChatGPT layout renders the message box as a plain text field instead of the rich editor the extension was built against. Both layouts are now recognized, and pasting keeps the cursor where you left it in either.
+- Fixed the de-anonymization banner not appearing on ChatGPT replies in that same layout.
 - Renamed the **Intercept clipboard** setting to **Intercept copy**. It only ever governed the offer to restore original values when you copy text out of a chat; it never affected the review of text you paste, which follows the master protection toggle. The old name suggested it covered both directions.
 - The privacy policy now has a Clipboard Access section spelling out when the extension reads or writes clipboard content, that it holds no clipboard permissions, and that it runs only on the supported chat sites.
 

--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -208,6 +208,12 @@ async function refreshSystemStatusFromBackground(): Promise<void> {
   }
 }
 
+/**
+ * Longer than the routine indicators: this one reports that protection is
+ * off, so it must survive a glance away from the screen.
+ */
+const INIT_FAILURE_INDICATOR_MS = 8000;
+
 function showIndicator(text: string, durationMs: number): void {
   const existing = document.getElementById('pg-indicator');
   if (existing) existing.remove();
@@ -673,7 +679,24 @@ void init().catch((error) => {
   interceptor.setEnabled(false);
   releasePasteInterceptor?.();
   releasePasteInterceptor = null;
-  if (settings?.debug) {
-    console.error('[PG:content] Initialization failed:', error);
-  }
+
+  // Report unconditionally — NOT behind `settings.debug`. Reaching here means
+  // paste review is off for the rest of this page's lifetime: there is no
+  // retry, and neither recovery listener can help (`chrome.storage.onChanged`
+  // is registered further down `init` and so was never reached, and a
+  // `SETTINGS_UPDATED` message cannot arrive if the runtime context is what
+  // failed). A privacy tool that has stopped reviewing pastes must say so
+  // rather than let the user keep pasting while believing they are covered.
+  console.error(
+    '[PG:content] Initialization failed — paste review is OFF for this page. '
+      + 'Reload the page to retry.',
+    error,
+  );
+
+  void waitForDocumentBody().then(() => {
+    showIndicator(
+      '\u26A0 Privacy Guardrail is off for this page \u2014 reload to retry',
+      INIT_FAILURE_INDICATOR_MS,
+    );
+  });
 });

--- a/src/content/paste-interceptor.ts
+++ b/src/content/paste-interceptor.ts
@@ -1,4 +1,5 @@
 import type { SiteAdapter } from './site-adapters/adapter-interface';
+import { isTextFormControl } from './site-adapters/adapter-interface';
 import type {
   CancelDetectionRequest,
   DetectPiiRequest,
@@ -42,11 +43,20 @@ export interface PasteInterceptorOptions {
   waitForReady?: () => Promise<void>;
 }
 
-/** Saved cursor/selection state so we can restore it after async detection. */
-interface SavedSelection {
-  range: Range;
-  inputElement: HTMLElement;
-}
+/**
+ * Saved cursor/selection state so we can restore it after async detection.
+ * `<textarea>` composers (ChatGPT's current client) keep their caret on
+ * `selectionStart`/`selectionEnd`, which no DOM Range can describe, so the
+ * two cases are tracked separately.
+ */
+type SavedSelection =
+  | { kind: 'range'; range: Range; inputElement: HTMLElement }
+  | {
+      kind: 'formControl';
+      start: number;
+      end: number;
+      inputElement: HTMLTextAreaElement | HTMLInputElement;
+    };
 
 /**
  * Manages paste event interception on a monitored LLM chat page.
@@ -123,12 +133,22 @@ export class PasteInterceptor {
     // Save the current cursor/selection before preventing default —
     // this lets us insert at the right position after async detection.
     this.savedSelection = null;
-    const selection = window.getSelection();
-    if (selection && selection.rangeCount > 0) {
+    if (isTextFormControl(inputElement)) {
       this.savedSelection = {
-        range: selection.getRangeAt(0).cloneRange(),
+        kind: 'formControl',
+        start: inputElement.selectionStart ?? inputElement.value.length,
+        end: inputElement.selectionEnd ?? inputElement.value.length,
         inputElement,
       };
+    } else {
+      const selection = window.getSelection();
+      if (selection && selection.rangeCount > 0) {
+        this.savedSelection = {
+          kind: 'range',
+          range: selection.getRangeAt(0).cloneRange(),
+          inputElement,
+        };
+      }
     }
 
     // Block the default paste
@@ -249,15 +269,27 @@ export class PasteInterceptor {
 
   /** Restore the saved cursor position so text inserts at the original caret. */
   private restoreSelection(): void {
-    if (!this.savedSelection) return;
-    const { range, inputElement } = this.savedSelection;
-    inputElement.focus();
+    const saved = this.savedSelection;
+    if (!saved) return;
+    this.savedSelection = null;
+
+    saved.inputElement.focus();
+
+    if (saved.kind === 'formControl') {
+      try {
+        saved.inputElement.setSelectionRange(saved.start, saved.end);
+      } catch {
+        // Input types such as `email` reject setSelectionRange; the insert
+        // still lands, just at the caret the browser chose on focus.
+      }
+      return;
+    }
+
     const selection = window.getSelection();
     if (selection) {
       selection.removeAllRanges();
-      selection.addRange(range);
+      selection.addRange(saved.range);
     }
-    this.savedSelection = null;
   }
 
   /** Insert original text into input (fallback on error). */

--- a/src/content/site-adapters/adapter-interface.ts
+++ b/src/content/site-adapters/adapter-interface.ts
@@ -25,11 +25,116 @@ export interface SiteAdapter {
   observeResponses(callback: (element: HTMLElement) => void): MutationObserver;
 }
 
+const TEXT_INPUT_TYPES = new Set(['text', 'search', 'url', 'email', 'tel', '']);
+
+/**
+ * True when the element is a form control whose caret lives on
+ * `selectionStart`/`selectionEnd` rather than in a DOM Range.
+ *
+ * Composers built on `<textarea>` (ChatGPT's current web client) must not be
+ * driven through `window.getSelection()`: a textarea's internal caret is not
+ * addressable as a Range, so adding one moves the selection outside the
+ * control and the insert lands in the wrong place — or nowhere.
+ *
+ * Uses `tagName` rather than `instanceof` so the check also holds for
+ * elements from another realm (e.g. inside an iframe).
+ */
+export function isTextFormControl(
+  element: HTMLElement | null,
+): element is HTMLTextAreaElement | HTMLInputElement {
+  if (!element) return false;
+  if (element.tagName === 'TEXTAREA') return true;
+  return (
+    element.tagName === 'INPUT' &&
+    TEXT_INPUT_TYPES.has((element as HTMLInputElement).type)
+  );
+}
+
+/**
+ * Run the `insertText` execCommand, reporting failure instead of throwing.
+ *
+ * execCommand is the only insertion path that both respects the caret and
+ * lets the site's own editor keep its state in sync, so it stays the first
+ * choice — but it is long deprecated and absent in some environments, so
+ * every caller must be able to fall back.
+ */
+function tryExecInsertText(text: string): boolean {
+  if (typeof document.execCommand !== 'function') return false;
+  try {
+    return document.execCommand('insertText', false, text);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Assign through the prototype's native `value` setter so frameworks that
+ * cache the last value they wrote (React and friends) still observe the
+ * change and do not revert the field on their next render.
+ */
+function setFormControlValue(
+  element: HTMLTextAreaElement | HTMLInputElement,
+  value: string,
+): void {
+  const prototype =
+    element.tagName === 'TEXTAREA'
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, 'value');
+  if (descriptor?.set) {
+    descriptor.set.call(element, value);
+  } else {
+    element.value = value;
+  }
+}
+
+/** Insert text at the caret of a `<textarea>` / `<input>` composer. */
+function insertIntoFormControl(
+  element: HTMLTextAreaElement | HTMLInputElement,
+  text: string,
+): void {
+  element.focus();
+
+  // execCommand respects the control's current selection and keeps both the
+  // site's own input handling and the browser undo stack intact.
+  if (tryExecInsertText(text)) return;
+
+  // Fallback: splice the text in at the caret ourselves.
+  const start = element.selectionStart ?? element.value.length;
+  const end = element.selectionEnd ?? start;
+  setFormControlValue(
+    element,
+    element.value.slice(0, start) + text + element.value.slice(end),
+  );
+
+  const caret = start + text.length;
+  try {
+    element.setSelectionRange(caret, caret);
+  } catch {
+    // Input types such as `email` reject setSelectionRange; the value is
+    // already correct, only the caret position is lost.
+  }
+
+  element.dispatchEvent(
+    new InputEvent('input', {
+      inputType: 'insertText',
+      data: text,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
 /**
  * Insert text using execCommand (deprecated but most reliable for contentEditable).
  * Falls back to InputEvent dispatch if execCommand fails.
  */
 export function insertTextCompat(element: HTMLElement, text: string): void {
+  if (isTextFormControl(element)) {
+    insertIntoFormControl(element, text);
+    return;
+  }
+
   element.focus();
 
   // Preserve the current selection/cursor position so the pasted text
@@ -47,7 +152,7 @@ export function insertTextCompat(element: HTMLElement, text: string): void {
 
   // Try execCommand first (works with React/ProseMirror state sync).
   // insertText replaces the current selection (or inserts at caret if collapsed).
-  const success = document.execCommand('insertText', false, text);
+  const success = tryExecInsertText(text);
 
   if (!success) {
     // Fallback: dispatch InputEvent — insert at caret via Range API

--- a/src/content/site-adapters/chatgpt-adapter.ts
+++ b/src/content/site-adapters/chatgpt-adapter.ts
@@ -1,27 +1,84 @@
 import type { SiteAdapter } from './adapter-interface';
 import { insertTextCompat } from './adapter-interface';
 
+/**
+ * ChatGPT serves two different web builds depending on auth state, and their
+ * DOM contracts share nothing. Both verified directly against chatgpt.com:
+ *
+ * - Signed out: assets under `/unauth-mweb/` (OpenAI's "web-mobile" bundle,
+ *   served at desktop widths too). The composer is a `<textarea>` tagged
+ *   `[data-mobile-composer-prompt]` — the selector the site's own scripts use
+ *   — and turns are marked `data-message-role`. No `#prompt-textarea` exists.
+ * - Signed in: the build this extension was written against. `#prompt-textarea`
+ *   is the live ProseMirror `contenteditable`, and turns are marked
+ *   `data-message-author-role`.
+ *
+ * Matching both is what makes the signed-out case work. The `isRendered`
+ * tie-break below is purely defensive: no observed page needs it, since the
+ * two contracts have so far never appeared together. It exists because
+ * matching two contracts introduces an ordering hazard that returning the
+ * first match unconditionally would hide — and the old code's unconditional
+ * `querySelector` failure mode was a silent no-op, which is the worst
+ * possible way for this to break.
+ */
+const INPUT_SELECTORS = [
+  '[data-mobile-composer-prompt]',
+  '#prompt-textarea',
+  'form textarea[name="prompt"]',
+  '[contenteditable="true"][role="textbox"]',
+  '[contenteditable="true"]',
+];
+
+const RESPONSE_SELECTOR =
+  '[data-message-role="assistant"], [data-message-author-role="assistant"]';
+
+/**
+ * Reject composer candidates the site itself treats as unusable. Mirrors
+ * ChatGPT's own guard (`disabled`, or nested in `[hidden]`/`[inert]`), which
+ * matters at desktop widths where a second, inert composer can be present.
+ * Deliberately avoids layout-dependent checks such as `offsetParent`, since
+ * the content script runs at `document_start`.
+ */
+function isUsableInput(element: HTMLElement): boolean {
+  if ((element as HTMLTextAreaElement).disabled) return false;
+  if (element.closest('[hidden],[inert]')) return false;
+  return true;
+}
+
+/**
+ * Whether the element is actually rendered. Only consulted to break ties
+ * between usable candidates: `getInputElement` runs on paste, long after
+ * layout, but must still return something if layout is unavailable.
+ */
+function isRendered(element: HTMLElement): boolean {
+  if (element.offsetParent !== null) return true;
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 || rect.height > 0;
+}
+
 export class ChatGptAdapter implements SiteAdapter {
   readonly name = 'ChatGPT';
 
   getInputElement(): HTMLElement | null {
-    // ChatGPT uses a contentEditable div inside the prompt form
-    // Prefer the ProseMirror editor if present
-    return (
-      document.querySelector<HTMLElement>('#prompt-textarea') ||
-      document.querySelector<HTMLElement>(
-        '[contenteditable="true"][role="textbox"]'
-      ) ||
-      document.querySelector<HTMLElement>('[contenteditable="true"]')
-    );
+    let fallback: HTMLElement | null = null;
+
+    for (const selector of INPUT_SELECTORS) {
+      const candidates = document.querySelectorAll<HTMLElement>(selector);
+      for (const candidate of candidates) {
+        if (!isUsableInput(candidate)) continue;
+        if (isRendered(candidate)) return candidate;
+        fallback ??= candidate;
+      }
+    }
+
+    // Nothing was rendered — either the page is still building or layout is
+    // unavailable. Returning the best match still beats dropping the paste.
+    return fallback;
   }
 
   getResponseElements(): HTMLElement[] {
-    // ChatGPT assistant messages have data-message-author-role="assistant"
     return Array.from(
-      document.querySelectorAll<HTMLElement>(
-        '[data-message-author-role="assistant"]'
-      )
+      document.querySelectorAll<HTMLElement>(RESPONSE_SELECTOR)
     );
   }
 
@@ -30,6 +87,9 @@ export class ChatGptAdapter implements SiteAdapter {
   }
 
   observeResponses(callback: (element: HTMLElement) => void): MutationObserver {
+    // Observe `main` (the app shell) rather than the transcript element:
+    // both clients replace the transcript on conversation switches, which
+    // would silently disconnect an observer bound to it.
     const container =
       document.querySelector('main') || document.body;
 

--- a/tests/content/chatgpt-adapter.test.ts
+++ b/tests/content/chatgpt-adapter.test.ts
@@ -1,0 +1,181 @@
+/** @jest-environment jsdom */
+
+import { ChatGptAdapter } from '../../src/content/site-adapters/chatgpt-adapter';
+import { PasteInterceptor, type PasteInterceptorCallbacks } from '../../src/content/paste-interceptor';
+import { DEFAULT_SETTINGS } from '../../src/shared/constants';
+
+const PASTE_TEXT = 'Synthetic private text that needs a review before it can be pasted.';
+
+/** Composer markup of ChatGPT's current "lightweight web" client. */
+function mountCurrentClient(): HTMLTextAreaElement {
+  document.body.innerHTML = `
+    <main>
+      <div data-conversation-transcript>
+        <div data-message-role="user">hello</div>
+        <div data-message-role="assistant"><div data-assistant-markdown>hi</div></div>
+      </div>
+      <form class="wm-composer-composer">
+        <textarea id="mobile-composer-prompt" class="wm-composer-textarea"
+                  data-mobile-composer-prompt name="prompt"></textarea>
+      </form>
+    </main>`;
+  return document.querySelector('textarea') as HTMLTextAreaElement;
+}
+
+/** Composer markup of the older React/ProseMirror client. */
+function mountLegacyClient(): HTMLElement {
+  document.body.innerHTML = `
+    <main>
+      <div data-message-author-role="user">hello</div>
+      <div data-message-author-role="assistant">hi</div>
+      <form>
+        <div id="prompt-textarea" contenteditable="true" role="textbox" class="ProseMirror"><p></p></div>
+      </form>
+    </main>`;
+  return document.querySelector('#prompt-textarea') as HTMLElement;
+}
+
+describe('ChatGptAdapter', () => {
+  const adapter = new ChatGptAdapter();
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  describe('current lightweight web client', () => {
+    it('finds the textarea composer', () => {
+      const composer = mountCurrentClient();
+      expect(adapter.getInputElement()).toBe(composer);
+    });
+
+    it('finds assistant turns marked with data-message-role', () => {
+      mountCurrentClient();
+      const responses = adapter.getResponseElements();
+      expect(responses).toHaveLength(1);
+      expect(responses[0].getAttribute('data-message-role')).toBe('assistant');
+    });
+
+    it('skips a composer the site has disabled or made inert', () => {
+      mountCurrentClient();
+      const composer = document.querySelector('textarea') as HTMLTextAreaElement;
+      composer.disabled = true;
+      expect(adapter.getInputElement()).toBeNull();
+
+      composer.disabled = false;
+      (composer.closest('form') as HTMLElement).setAttribute('inert', '');
+      expect(adapter.getInputElement()).toBeNull();
+    });
+
+    it('prefers a rendered composer over a hidden one from another build', () => {
+      // Guards the ordering risk: a build that ships both a hidden mweb
+      // composer and a live ProseMirror one must not resolve to the hidden one.
+      document.body.innerHTML = `
+        <main>
+          <form>
+            <textarea data-mobile-composer-prompt name="prompt"></textarea>
+            <div id="prompt-textarea" contenteditable="true" role="textbox"><p></p></div>
+          </form>
+        </main>`;
+      const hidden = document.querySelector('textarea') as HTMLTextAreaElement;
+      const live = document.querySelector('#prompt-textarea') as HTMLElement;
+
+      // jsdom reports no layout for either, so pin the distinction explicitly.
+      jest.spyOn(hidden, 'getBoundingClientRect').mockReturnValue({ width: 0, height: 0 } as DOMRect);
+      jest.spyOn(live, 'getBoundingClientRect').mockReturnValue({ width: 400, height: 40 } as DOMRect);
+
+      expect(adapter.getInputElement()).toBe(live);
+    });
+
+    it('still returns a match when no candidate reports layout', () => {
+      const composer = mountCurrentClient();
+      // jsdom gives every element a zero rect; the composer must not be dropped.
+      expect(adapter.getInputElement()).toBe(composer);
+    });
+
+    it('inserts at the caret without clobbering existing text', () => {
+      const composer = mountCurrentClient();
+      composer.value = 'AB';
+      composer.focus();
+      composer.setSelectionRange(1, 1);
+
+      adapter.insertText(composer, 'X');
+
+      expect(composer.value).toBe('AXB');
+    });
+  });
+
+  describe('legacy React client', () => {
+    it('still finds the ProseMirror composer', () => {
+      const composer = mountLegacyClient();
+      expect(adapter.getInputElement()).toBe(composer);
+    });
+
+    it('still finds assistant turns marked with data-message-author-role', () => {
+      mountLegacyClient();
+      const responses = adapter.getResponseElements();
+      expect(responses).toHaveLength(1);
+      expect(responses[0].getAttribute('data-message-author-role')).toBe('assistant');
+    });
+  });
+});
+
+describe('PasteInterceptor on the current ChatGPT client', () => {
+  const makeCallbacks = (): PasteInterceptorCallbacks & Record<string, jest.Mock> => ({
+    onAnalyzing: jest.fn(),
+    onNoPii: jest.fn(),
+    onPiiDetected: jest.fn(),
+    onError: jest.fn(),
+    onCanceled: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    document.body.replaceChildren();
+    (chrome.storage.local.get as jest.Mock).mockResolvedValue({
+      pg_settings: DEFAULT_SETTINGS,
+    });
+  });
+
+  it('holds a paste into the textarea composer for review', async () => {
+    const composer = mountCurrentClient();
+    const callbacks = makeCallbacks();
+    const interceptor = new PasteInterceptor(new ChatGptAdapter(), callbacks);
+    interceptor.start();
+
+    const paste = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(paste, 'clipboardData', {
+      value: { getData: () => PASTE_TEXT },
+    });
+    composer.dispatchEvent(paste);
+
+    expect(paste.defaultPrevented).toBe(true);
+    await Promise.resolve();
+    expect(callbacks.onAnalyzing).toHaveBeenCalledTimes(1);
+
+    interceptor.stop();
+  });
+
+  it('restores the textarea caret when it pastes the original text back', () => {
+    const composer = mountCurrentClient();
+    composer.value = 'AB';
+    const interceptor = new PasteInterceptor(new ChatGptAdapter(), makeCallbacks());
+    interceptor.start();
+
+    composer.focus();
+    composer.setSelectionRange(1, 1);
+
+    const paste = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(paste, 'clipboardData', {
+      value: { getData: () => PASTE_TEXT },
+    });
+    composer.dispatchEvent(paste);
+
+    // The overlay's "paste original" path runs after the caret has moved on.
+    composer.setSelectionRange(2, 2);
+    interceptor.pasteOriginal('X');
+
+    expect(composer.value).toBe(`AXB`);
+
+    interceptor.stop();
+  });
+});


### PR DESCRIPTION
ChatGPT serves two web builds with unrelated DOM contracts, and the adapter only knew one of them.

Signed out, chatgpt.com ships the "web-mobile" bundle (assets under `/unauth-mweb/`, served at desktop widths too). Its composer is a `<textarea data-mobile-composer-prompt>` and its turns are marked `data-message-role`. There is no `#prompt-textarea` and no `data-message-author-role`, which is all the adapter looked for — so on that layout `getInputElement()` returned null, pastes went through unreviewed, and no de-anonymization banner ever attached.

## What changed

**Both contracts are matched.** Candidates the site itself treats as unusable (`disabled`, or nested in `[hidden]`/`[inert]`) are skipped, and a rendered candidate wins over a non-rendered one. The `isRendered` tie-break is defensive — no observed page ships both composers — but matching two contracts introduces an ordering hazard, and the old failure mode was a silent no-op, which is the worst way for this to break. Layout-dependent checks are avoided where possible since the content script runs at `document_start`.

**A `<textarea>` needs a different insertion path than contenteditable.** Its caret lives on `selectionStart`/`selectionEnd` and cannot be described by a DOM Range, so saving and restoring the selection through `window.getSelection()` moved the selection outside the control and the text landed in the wrong place, or nowhere. `PasteInterceptor` now tracks the two cases separately, and `insertTextCompat` splices into form controls through the prototype's native `value` setter so React does not revert the field on its next render.

**Init failure is now visible.** Reaching the `init` catch means paste review is off for the rest of the page's lifetime: there is no retry, and neither recovery listener can help — `chrome.storage.onChanged` is registered later in `init` and so was never reached, and a `SETTINGS_UPDATED` message cannot arrive if the runtime context is what failed. This was reported only behind `settings.debug`, so in the normal case the extension went quiet and the user kept pasting while believing they were covered. It now logs unconditionally and shows an on-page warning asking for a reload.

## Verification

`tests/content/chatgpt-adapter.test.ts` covers both layouts: composer discovery, assistant-turn discovery, the disabled/inert skips, the rendered-over-hidden tie-break, caret-preserving insertion, and a paste held for review on the textarea composer.

`tsc --noEmit`, the full jest suite, and `node scripts/validate.js ci` all pass. The DOM contracts were verified directly against chatgpt.com; the automated coverage is jsdom-level.
