### PR TITLE
Keep replacements when a new chat gets its own URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows public beta release notes for `0.x` versions.
 
 ## Unreleased
 
+- Fixed replaced values being forgotten once a new chat got its own address. Starting a chat, pasting something that was replaced and sending it moves the page from the "new chat" screen to the conversation's own URL, and the replacements stayed filed under the screen you left — so after a reload the reply could no longer be turned back into your original values. They now move with the conversation, and switching between existing chats without a page reload loads the right conversation's replacements.
+- Fixed the reveal banner missing replies that arrive in bursts. A reply that paused mid-stream for longer than half a second was only inspected up to that pause, and a reply that was still empty when first checked was written off for good — in both cases the replaced values that arrived afterwards were never offered for reveal.
 - Fixed Privacy Guardrail not recognizing the message box on ChatGPT when signed out, so no review was offered before pasting. That ChatGPT layout renders the message box as a plain text field instead of the rich editor the extension was built against. Both layouts are now recognized, and pasting keeps the cursor where you left it in either.
 - Fixed the de-anonymization banner not appearing on ChatGPT replies in that same layout.
 - Privacy Guardrail now tells you when it has switched itself off. If it fails to start on a page, pastes are no longer reviewed for the rest of that page's visit, and it previously gave no sign of this at all — so you could keep pasting while believing you were covered. It now shows a warning on the page and asks you to reload.

--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -35,6 +35,7 @@ import {
   loadEntityMap,
   saveEntityMap,
   migrateEntityMap,
+  ownedEntries,
   logFeedback,
 } from '../shared/storage';
 import { findConflictingPattern } from '../shared/list-conflicts';
@@ -93,6 +94,24 @@ let adaptiveThresholds: Record<string, number> = {};
  * mappings to match.
  */
 let conversationUrl = normalizeConversationUrl(window.location.href);
+
+/**
+ * Replacement tokens this page session has actually emitted into the page.
+ *
+ * The in-memory map is restored from storage on load, and on the "new chat"
+ * screen that key is shared with every other tab composing its own first
+ * message. Persisting the map wholesale would file those other sessions'
+ * originals under this conversation. Only what this session used is written
+ * back — see `ownedEntries`.
+ */
+const sessionPlaceholders = new Set<string>();
+
+/**
+ * Guards against overlapping conversation loads. A storage read started for
+ * one conversation can resolve after a later one's, and the loser must not
+ * install its map over the winner's.
+ */
+let conversationGeneration = 0;
 
 function normalizeConversationUrl(href: string): string {
   return href.split('?')[0].split('#')[0];
@@ -289,24 +308,42 @@ function watchConversationUrl(): void {
 }
 
 async function handleConversationChange(previous: string, next: string): Promise<void> {
+  const generation = ++conversationGeneration;
+
   const leftNewChatScreen = adapter.hasConversationId
     ? !adapter.hasConversationId(previous) && adapter.hasConversationId(next)
     : false;
 
-  if (leftNewChatScreen && entityMap.size > 0) {
+  if (leftNewChatScreen) {
     // The site has just created the conversation and rewritten the URL.
     // Move the mappings recorded while composing onto the URL the user will
     // come back to, otherwise they are stranded under the "new chat" key.
-    await migrateEntityMap(previous, next, entityMap.toStored());
+    // Still the same conversation, so the map stays as it is either way.
+    const owned = ownedEntries(entityMap.toStored(), sessionPlaceholders);
+    const count = Object.keys(owned).length;
+    if (count > 0) {
+      await migrateEntityMap(previous, next, owned);
+    }
     if (settings?.debug) {
-      console.log(`[PG:content] Conversation created; ${entityMap.size} mapping(s) moved to ${next}`);
+      console.log(`[PG:content] Conversation created; ${count} mapping(s) moved to ${next}`);
     }
     return;
   }
 
   // A genuinely different conversation. Adopt its stored mappings rather
   // than carrying the previous conversation's state into it.
-  entityMap = new EntityMap(await loadEntityMap(next));
+  const stored = await loadEntityMap(next);
+  if (generation !== conversationGeneration) {
+    // A further navigation started while this read was in flight and owns
+    // the map now. Installing this one would leave the wrong conversation's
+    // originals resolvable — and persist them under the current URL on the
+    // next paste.
+    return;
+  }
+  entityMap = new EntityMap(stored);
+  // Restored entries belong to that conversation's earlier sessions, not to
+  // this one, so this session has emitted nothing yet.
+  sessionPlaceholders.clear();
   if (settings?.debug) {
     console.log(`[PG:content] Switched conversation; ${entityMap.size} mapping(s) restored`);
   }
@@ -410,9 +447,22 @@ function showReviewOverlay(
 
         interceptor.pasteAnonymized(anonymizedText);
 
+        // Record what this session put into the page. The map may also hold
+        // entries restored from storage — on the shared "new chat" key those
+        // can belong to another tab's draft — and those are not ours to
+        // persist or migrate.
+        for (const [replacement] of entityMap.entries()) {
+          if (anonymizedText.includes(replacement)) {
+            sessionPlaceholders.add(replacement);
+          }
+        }
+
         // Persist conversation-scoped map (still used by the de-anon banner
         // for the current view, regardless of vault state).
-        saveEntityMap(conversationUrl, entityMap.toStored());
+        saveEntityMap(
+          conversationUrl,
+          ownedEntries(entityMap.toStored(), sessionPlaceholders),
+        );
 
         showIndicator(
           `\u{1F512} ${approvedSpans.length} item(s) replaced`,

--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -34,6 +34,7 @@ import {
   saveSettings,
   loadEntityMap,
   saveEntityMap,
+  migrateEntityMap,
   logFeedback,
 } from '../shared/storage';
 import { findConflictingPattern } from '../shared/list-conflicts';
@@ -58,7 +59,7 @@ import {
 } from '../shared/feedback';
 import { prepareReviewSpans } from './review-spans';
 import { resolveThreshold } from '../shared/sensitivity-resolver';
-import { LOCAL_AI_ACTIVITY_HEARTBEAT_MS, NO_PII_INDICATOR_MS, CHIP_FADE_MS } from '../shared/constants';
+import { CONVERSATION_URL_POLL_MS, LOCAL_AI_ACTIVITY_HEARTBEAT_MS, NO_PII_INDICATOR_MS, CHIP_FADE_MS } from '../shared/constants';
 import type { PiiSpan, FeedbackEntry, Settings, AllowlistEntry, CancelDetectionBehavior, NerStatus, NerStatusResponse, SystemCompatibilityStatus, SystemCompatibilityStatusResponse } from '../shared/message-types';
 
 // --- Adapter selection ---
@@ -83,7 +84,19 @@ const adapter = selectAdapter();
 let entityMap = new EntityMap();
 let settings: Settings;
 let adaptiveThresholds: Record<string, number> = {};
-const conversationUrl = window.location.href.split('?')[0];
+/**
+ * Storage key for this conversation's placeholder mappings.
+ *
+ * Not a constant: chat sites create the conversation on the first send and
+ * rewrite the URL in place, and users switch conversations without a page
+ * load. `watchConversationUrl` keeps this current and moves or reloads the
+ * mappings to match.
+ */
+let conversationUrl = normalizeConversationUrl(window.location.href);
+
+function normalizeConversationUrl(href: string): string {
+  return href.split('?')[0].split('#')[0];
+}
 let scanningIndicator: ScanningIndicator | null = null;
 let pageStatusChip: PageStatusChip | null = null;
 let lastSystemStatus: SystemCompatibilityStatus | null = null;
@@ -245,6 +258,50 @@ function showIndicator(text: string, durationMs: number): void {
     el.style.opacity = '0';
     setTimeout(() => el.remove(), 300);
   }, durationMs);
+}
+
+/**
+ * Keep `conversationUrl` in step with same-document navigation.
+ *
+ * Content scripts run in an isolated world, so patching `history.pushState`
+ * here would never observe the page's own calls. Polling the URL is the
+ * dependable option; `popstate` is added so back/forward registers at once.
+ */
+function watchConversationUrl(): void {
+  const check = (): void => {
+    const next = normalizeConversationUrl(window.location.href);
+    if (next === conversationUrl) return;
+    const previous = conversationUrl;
+    conversationUrl = next;
+    void handleConversationChange(previous, next);
+  };
+
+  window.addEventListener('popstate', check);
+  window.setInterval(check, CONVERSATION_URL_POLL_MS);
+}
+
+async function handleConversationChange(previous: string, next: string): Promise<void> {
+  const leftNewChatScreen = adapter.hasConversationId
+    ? !adapter.hasConversationId(previous) && adapter.hasConversationId(next)
+    : false;
+
+  if (leftNewChatScreen && entityMap.size > 0) {
+    // The site has just created the conversation and rewritten the URL.
+    // Move the mappings recorded while composing onto the URL the user will
+    // come back to, otherwise they are stranded under the "new chat" key.
+    await migrateEntityMap(previous, next, entityMap.toStored());
+    if (settings?.debug) {
+      console.log(`[PG:content] Conversation created; ${entityMap.size} mapping(s) moved to ${next}`);
+    }
+    return;
+  }
+
+  // A genuinely different conversation. Adopt its stored mappings rather
+  // than carrying the previous conversation's state into it.
+  entityMap = new EntityMap(await loadEntityMap(next));
+  if (settings?.debug) {
+    console.log(`[PG:content] Switched conversation; ${entityMap.size} mapping(s) restored`);
+  }
 }
 
 function waitForDocumentBody(): Promise<void> {
@@ -659,6 +716,7 @@ async function init(): Promise<void> {
 
   // Start observation and clipboard restoration after the DOM is available.
   startSupportedPageActivityHeartbeat();
+  watchConversationUrl();
   responseObserver.start();
   clipboardInterceptor.setTheme(settings.theme);
   clipboardInterceptor.setEnabled(settings.clipboardInterceptEnabled);

--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -268,6 +268,14 @@ function showIndicator(text: string, durationMs: number): void {
  * dependable option; `popstate` is added so back/forward registers at once.
  */
 function watchConversationUrl(): void {
+  // An adapter that cannot tell a persisted conversation from a "new chat"
+  // screen makes every URL change uninterpretable: on an unrecognised site a
+  // route change need not mean the conversation changed, and adopting a
+  // different map on that guess would drop mappings the current page can
+  // still reveal. Those sites keep the documented fallback — the load-time
+  // URL for the lifetime of the page.
+  if (!adapter.hasConversationId) return;
+
   const check = (): void => {
     const next = normalizeConversationUrl(window.location.href);
     if (next === conversationUrl) return;

--- a/src/content/response-observer.ts
+++ b/src/content/response-observer.ts
@@ -56,6 +56,12 @@ export class ResponseObserver {
       observer.disconnect();
     }
     this.elementObservers = [];
+    // Drop the per-element bookkeeping along with the observers it describes.
+    // Keeping it would make a later `start()` treat elements whose observers
+    // were just disconnected as still watched, so they would never be
+    // re-observed.
+    this.watched = new WeakSet();
+    this.lastCheckedText = new WeakMap();
     for (const timer of this.debounceTimers.values()) {
       clearTimeout(timer);
     }

--- a/src/content/response-observer.ts
+++ b/src/content/response-observer.ts
@@ -20,6 +20,14 @@ export class ResponseObserver {
   private callbacks: ResponseObserverCallbacks;
   private observer: MutationObserver | null = null;
   private debounceTimers = new Map<HTMLElement, number>();
+  /** Per-element observers, kept connected for the element's lifetime so
+   *  content that streams in after a pause is still noticed. Disconnected
+   *  together in `stop()`. */
+  private elementObservers: MutationObserver[] = [];
+  private watched = new WeakSet<HTMLElement>();
+  /** Text each element was last checked with, so a re-fire that carries no
+   *  new content skips the storage read behind `onResponseWithPlaceholders`. */
+  private lastCheckedText = new WeakMap<HTMLElement, string>();
 
   constructor(adapter: SiteAdapter, callbacks: ResponseObserverCallbacks) {
     this.adapter = adapter;
@@ -44,6 +52,10 @@ export class ResponseObserver {
       this.observer.disconnect();
       this.observer = null;
     }
+    for (const observer of this.elementObservers) {
+      observer.disconnect();
+    }
+    this.elementObservers = [];
     for (const timer of this.debounceTimers.values()) {
       clearTimeout(timer);
     }
@@ -55,32 +67,49 @@ export class ResponseObserver {
    * placeholders once the content stabilizes.
    */
   private watchElement(element: HTMLElement): void {
-    const innerObserver = new MutationObserver(() => {
-      // Debounce: reset timer on each mutation
-      const existing = this.debounceTimers.get(element);
-      if (existing) clearTimeout(existing);
+    if (this.watched.has(element)) return;
+    this.watched.add(element);
 
-      const timer = window.setTimeout(() => {
-        this.debounceTimers.delete(element);
-        innerObserver.disconnect();
-        this.checkForPlaceholders(element);
-      }, RESPONSE_DEBOUNCE_MS);
-
-      this.debounceTimers.set(element, timer);
-    });
+    const innerObserver = new MutationObserver(() => this.scheduleCheck(element));
 
     innerObserver.observe(element, {
       childList: true,
       subtree: true,
       characterData: true,
     });
+    // Deliberately never disconnected here. A reply can arrive in several
+    // bursts with pauses longer than the debounce window between them — a
+    // one-shot observer stops listening during the first pause and never
+    // sees the placeholders that stream in afterwards.
+    this.elementObservers.push(innerObserver);
 
-    // Also do an immediate check in case content is already complete
-    setTimeout(() => this.checkForPlaceholders(element), RESPONSE_DEBOUNCE_MS);
+    // Covers an element that is appended already complete and never mutates
+    // again. Shares the debounce timer, so a streaming element schedules once
+    // here and merely resets it on each mutation rather than double-firing.
+    this.scheduleCheck(element);
+  }
+
+  /** Debounced check: resets on every call, fires once content settles. */
+  private scheduleCheck(element: HTMLElement): void {
+    const existing = this.debounceTimers.get(element);
+    if (existing) clearTimeout(existing);
+
+    const timer = window.setTimeout(() => {
+      this.debounceTimers.delete(element);
+      this.checkForPlaceholders(element);
+    }, RESPONSE_DEBOUNCE_MS);
+
+    this.debounceTimers.set(element, timer);
   }
 
   private checkForPlaceholders(element: HTMLElement): void {
     const text = collectResponseText(element);
+    // The observer stays connected for the element's lifetime, so it also
+    // fires for mutations that carry no new content — including the reveal
+    // overlay this extension appends itself. Skip those: the banner attach
+    // is idempotent anyway, but the storage read behind it is not free.
+    if (this.lastCheckedText.get(element) === text) return;
+    this.lastCheckedText.set(element, text);
     // Permissive shape gate so the banner-attach path also fires for
     // responses where every placeholder was mangled (`PERSON 1`,
     // `person_1`, …). False positives are harmless: the banner re-checks

--- a/src/content/site-adapters/adapter-interface.ts
+++ b/src/content/site-adapters/adapter-interface.ts
@@ -23,6 +23,30 @@ export interface SiteAdapter {
    * Calls the callback with each new response element.
    */
   observeResponses(callback: (element: HTMLElement) => void): MutationObserver;
+
+  /**
+   * True when the URL identifies a persisted conversation rather than the
+   * site's "new chat" screen.
+   *
+   * Every supported site creates a conversation on the first send and then
+   * rewrites the URL in place (`/new` -> `/chat/<uuid>`, `/` -> `/c/<uuid>`,
+   * ...). Placeholder mappings recorded before that rewrite are filed under
+   * the transient URL and would be unreachable on the next visit, so the
+   * content script uses this to detect the rewrite and move them across.
+   *
+   * Adapters that do not implement it keep the old behaviour: the URL at
+   * load time is used for the lifetime of the page.
+   */
+  hasConversationId?(url: string): boolean;
+}
+
+/** Path portion of a URL, tolerant of values that are not parseable. */
+export function urlPath(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
 }
 
 const TEXT_INPUT_TYPES = new Set(['text', 'search', 'url', 'email', 'tel', '']);

--- a/src/content/site-adapters/chatgpt-adapter.ts
+++ b/src/content/site-adapters/chatgpt-adapter.ts
@@ -1,5 +1,5 @@
 import type { SiteAdapter } from './adapter-interface';
-import { insertTextCompat } from './adapter-interface';
+import { insertTextCompat, urlPath } from './adapter-interface';
 
 /**
  * ChatGPT serves two different web builds depending on auth state, and their
@@ -58,6 +58,11 @@ function isRendered(element: HTMLElement): boolean {
 
 export class ChatGptAdapter implements SiteAdapter {
   readonly name = 'ChatGPT';
+
+  hasConversationId(url: string): boolean {
+    // chatgpt.com/ -> /c/<uuid>; GPTs land on /g/<slug> then /g/<slug>/c/<uuid>.
+    return urlPath(url).includes('/c/');
+  }
 
   getInputElement(): HTMLElement | null {
     let fallback: HTMLElement | null = null;

--- a/src/content/site-adapters/claude-adapter.ts
+++ b/src/content/site-adapters/claude-adapter.ts
@@ -1,8 +1,13 @@
 import type { SiteAdapter } from './adapter-interface';
-import { insertTextCompat } from './adapter-interface';
+import { insertTextCompat, urlPath } from './adapter-interface';
 
 export class ClaudeAdapter implements SiteAdapter {
   readonly name = 'Claude';
+
+  hasConversationId(url: string): boolean {
+    // claude.ai/new -> claude.ai/chat/<uuid> after the first send.
+    return /^\/chat\/[^/]+/.test(urlPath(url));
+  }
 
   getInputElement(): HTMLElement | null {
     return (

--- a/src/content/site-adapters/gemini-adapter.ts
+++ b/src/content/site-adapters/gemini-adapter.ts
@@ -1,8 +1,13 @@
 import type { SiteAdapter } from './adapter-interface';
-import { insertTextCompat } from './adapter-interface';
+import { insertTextCompat, urlPath } from './adapter-interface';
 
 export class GeminiAdapter implements SiteAdapter {
   readonly name = 'Gemini';
+
+  hasConversationId(url: string): boolean {
+    // gemini.google.com/app -> /app/<id> after the first send.
+    return /^\/app\/[^/]+/.test(urlPath(url));
+  }
 
   getInputElement(): HTMLElement | null {
     // Gemini uses a rich text editor with contentEditable

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -15,6 +15,9 @@ export const MIN_PASTE_LENGTH = 10;
 /** Maximum text length before chunking for NER. */
 export const MAX_TEXT_LENGTH = 5000;
 
+/** How often (ms) to re-read the URL for same-document navigation. */
+export const CONVERSATION_URL_POLL_MS = 500;
+
 /** Delay (ms) before de-anonymizing a streaming response. */
 export const RESPONSE_DEBOUNCE_MS = 500;
 

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -191,6 +191,29 @@ export async function loadEntityMap(
 }
 
 /**
+ * Narrow a map to the entries whose replacement token a single page session
+ * actually emitted into the page.
+ *
+ * The "new chat" URL is a shared key: every new conversation in every tab
+ * files its mappings under it until the site assigns a real one. A session
+ * restores that key on load, so its in-memory map can hold entries belonging
+ * to other sessions' drafts. Persisting or migrating the map wholesale would
+ * carry those originals into this conversation, where its reveal banner
+ * would resolve placeholders it never sent. Both writers pass their entries
+ * through here so a session only ever stores what it used.
+ */
+export function ownedEntries(
+  map: StoredEntityMap,
+  owned: ReadonlySet<string>,
+): StoredEntityMap {
+  const result: StoredEntityMap = {};
+  for (const [replacement, original] of Object.entries(map)) {
+    if (owned.has(replacement)) result[replacement] = original;
+  }
+  return result;
+}
+
+/**
  * Move placeholder mappings recorded before a conversation existed onto the
  * URL the site assigned it.
  *

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -190,6 +190,43 @@ export async function loadEntityMap(
   return maps[conversationUrl] || {};
 }
 
+/**
+ * Move placeholder mappings recorded before a conversation existed onto the
+ * URL the site assigned it.
+ *
+ * Every supported chat site creates the conversation on the first send and
+ * rewrites the URL in place. Anything anonymized while composing is filed
+ * under the transient "new chat" URL, so without this the mappings become
+ * unreachable the moment the page is reloaded.
+ *
+ * Only the supplied entries move — the ones this page session actually
+ * produced. A second tab composing its own new chat keeps its pending
+ * mappings under the transient URL untouched.
+ */
+export async function migrateEntityMap(
+  fromUrl: string,
+  toUrl: string,
+  entries: StoredEntityMap,
+): Promise<void> {
+  const keys = Object.keys(entries);
+  if (keys.length === 0 || fromUrl === toUrl) return;
+
+  const result = await chrome.storage.local.get(ENTITY_MAPS_KEY);
+  const maps: Record<string, StoredEntityMap> = result[ENTITY_MAPS_KEY] || {};
+
+  maps[toUrl] = { ...maps[toUrl], ...entries };
+
+  const source = maps[fromUrl];
+  if (source) {
+    for (const key of keys) {
+      if (source[key] === entries[key]) delete source[key];
+    }
+    if (Object.keys(source).length === 0) delete maps[fromUrl];
+  }
+
+  await chrome.storage.local.set({ [ENTITY_MAPS_KEY]: maps });
+}
+
 /** Clear entity maps for a specific conversation or all conversations. */
 export async function clearEntityMaps(conversationUrl?: string): Promise<void> {
   if (conversationUrl) {

--- a/src/ui/banner/de-anon-banner.ts
+++ b/src/ui/banner/de-anon-banner.ts
@@ -56,7 +56,6 @@ export function attachDeAnonBanner(
 ): void {
   // Don't attach twice
   if (responseElement.dataset.pgBanner === 'attached') return;
-  responseElement.dataset.pgBanner = 'attached';
 
   // Build a combined detection text spanning visible markdown and any
   // descendant form-control values (artifact cards render their content
@@ -71,6 +70,12 @@ export function attachDeAnonBanner(
   const { matches } = resolveText(text, entityMap);
   const totalRevealable = matches.length;
   if (totalRevealable === 0) return;
+
+  // Claim the element only once a banner is actually going to be rendered.
+  // Marking it before the bail-out above would permanently suppress the
+  // banner for any element first inspected while its content was still
+  // streaming and had nothing resolvable yet.
+  responseElement.dataset.pgBanner = 'attached';
 
   // Create banner host with Shadow DOM
   const host = document.createElement('div');

--- a/tests/content/response-observer.test.ts
+++ b/tests/content/response-observer.test.ts
@@ -114,6 +114,31 @@ describe('ResponseObserver streaming behaviour', () => {
     expect(onResponseWithPlaceholders).toHaveBeenCalledTimes(1);
   });
 
+  it('watches an element again after a stop()/start() cycle', async () => {
+    const onResponseWithPlaceholders = jest.fn();
+    observer = new ResponseObserver(makeAdapter(), { onResponseWithPlaceholders });
+    observer.start();
+
+    const el = appendResponse();
+    await wait(20);
+
+    // stop() disconnects the element's observer, so the bookkeeping that
+    // records it as watched has to go with it — otherwise the element is
+    // never re-observed and its reply stays unrevealable.
+    observer.stop();
+    observer.start();
+
+    // The restarted observer needs a fresh mutation to notice the element
+    // again, exactly as it would on a live page.
+    document.body.append(document.createElement('span'));
+    await wait(20);
+
+    el.textContent = 'Reply after restart mentioning [PERSON_1]';
+    await wait(SETTLE);
+
+    expect(onResponseWithPlaceholders).toHaveBeenCalledTimes(1);
+  });
+
   it('stops watching elements after stop()', async () => {
     const onResponseWithPlaceholders = jest.fn();
     observer = new ResponseObserver(makeAdapter(), { onResponseWithPlaceholders });

--- a/tests/content/response-observer.test.ts
+++ b/tests/content/response-observer.test.ts
@@ -1,0 +1,131 @@
+/** @jest-environment jsdom */
+
+import { ResponseObserver } from '../../src/content/response-observer';
+import type { SiteAdapter } from '../../src/content/site-adapters/adapter-interface';
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Slightly longer than RESPONSE_DEBOUNCE_MS (500) so a settle can complete. */
+const SETTLE = 700;
+
+/**
+ * Mirrors how a streaming chat page behaves: response elements are appended
+ * empty while the model is still generating, then filled in one or more
+ * bursts. Langdock in particular pauses between markdown blocks.
+ */
+function makeAdapter(): SiteAdapter {
+  const getEls = () =>
+    Array.from(document.querySelectorAll<HTMLElement>('[data-response]'));
+
+  return {
+    name: 'streaming-site',
+    getInputElement: () => null,
+    insertText: jest.fn(),
+    getResponseElements: getEls,
+    observeResponses: (cb) => {
+      const seen = new WeakSet<HTMLElement>();
+      const observer = new MutationObserver(() => {
+        for (const el of getEls()) {
+          if (!seen.has(el)) {
+            seen.add(el);
+            cb(el);
+          }
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+      return observer;
+    },
+  };
+}
+
+function appendResponse(): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('data-response', '');
+  document.body.append(el);
+  return el;
+}
+
+describe('ResponseObserver streaming behaviour', () => {
+  let observer: ResponseObserver | null = null;
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  afterEach(() => {
+    observer?.stop();
+    observer = null;
+  });
+
+  it('reports an element filled in a single burst exactly once', async () => {
+    const onResponseWithPlaceholders = jest.fn();
+    observer = new ResponseObserver(makeAdapter(), { onResponseWithPlaceholders });
+    observer.start();
+
+    const el = appendResponse();
+    await wait(20);
+
+    el.textContent = 'Absatz 1 — [PERSON_1] besucht den Supermarkt';
+    await wait(SETTLE);
+
+    // Previously fired twice: once from an unconditional timer in
+    // watchElement and again via the debounce path.
+    expect(onResponseWithPlaceholders).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports placeholders that stream in after a pause longer than the debounce', async () => {
+    const onResponseWithPlaceholders = jest.fn();
+    observer = new ResponseObserver(makeAdapter(), { onResponseWithPlaceholders });
+    observer.start();
+
+    // Appended empty while the previous block is still generating.
+    const el = appendResponse();
+    await wait(20);
+
+    // Heading arrives, then the model pauses past the debounce window. The
+    // old one-shot observer disconnected here and never looked again.
+    el.textContent = 'Absatz 2 — Kontaktdaten';
+    await wait(SETTLE);
+    expect(onResponseWithPlaceholders).not.toHaveBeenCalled();
+
+    // The rest of the paragraph, carrying the placeholders.
+    el.textContent = 'Absatz 2 — Kontaktdaten [PERSON_1], [EMAIL_3], [PHONE_3]';
+    await wait(SETTLE);
+
+    expect(onResponseWithPlaceholders).toHaveBeenCalledTimes(1);
+    expect(onResponseWithPlaceholders.mock.calls[0][1]).toContain('[PERSON_1]');
+  });
+
+  it('does not re-report an element whose content has not changed', async () => {
+    const onResponseWithPlaceholders = jest.fn();
+    observer = new ResponseObserver(makeAdapter(), { onResponseWithPlaceholders });
+    observer.start();
+
+    const el = appendResponse();
+    await wait(20);
+    el.textContent = 'Reply mentioning [PERSON_1]';
+    await wait(SETTLE);
+
+    // A mutation that carries no new text — e.g. the reveal overlay this
+    // extension appends itself, or a framework re-render.
+    el.setAttribute('data-decorated', 'true');
+    await wait(SETTLE);
+
+    expect(onResponseWithPlaceholders).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops watching elements after stop()', async () => {
+    const onResponseWithPlaceholders = jest.fn();
+    observer = new ResponseObserver(makeAdapter(), { onResponseWithPlaceholders });
+    observer.start();
+
+    const el = appendResponse();
+    await wait(20);
+    observer.stop();
+
+    el.textContent = 'Late reply with [PERSON_1]';
+    await wait(SETTLE);
+
+    expect(onResponseWithPlaceholders).not.toHaveBeenCalled();
+  });
+});

--- a/tests/content/site-adapters/conversation-id.test.ts
+++ b/tests/content/site-adapters/conversation-id.test.ts
@@ -1,0 +1,41 @@
+/** @jest-environment jsdom */
+
+import { ChatGptAdapter } from '../../../src/content/site-adapters/chatgpt-adapter';
+import { ClaudeAdapter } from '../../../src/content/site-adapters/claude-adapter';
+import { GeminiAdapter } from '../../../src/content/site-adapters/gemini-adapter';
+
+/**
+ * `hasConversationId` decides whether a URL identifies a persisted
+ * conversation or the site's "new chat" screen. The content script uses the
+ * false -> true transition to detect that the site has just created the
+ * conversation, so pending placeholder mappings can be moved onto the URL the
+ * user will return to.
+ */
+describe.each([
+  [
+    'Claude',
+    new ClaudeAdapter(),
+    ['https://claude.ai/chat/9f1c-2b', 'https://claude.ai/chat/9f1c-2b?x=1'],
+    ['https://claude.ai/new', 'https://claude.ai/', 'https://claude.ai/chats'],
+  ],
+  [
+    'ChatGPT',
+    new ChatGptAdapter(),
+    ['https://chatgpt.com/c/9f1c-2b', 'https://chatgpt.com/g/g-abc/c/9f1c-2b'],
+    ['https://chatgpt.com/', 'https://chatgpt.com/g/g-abc'],
+  ],
+  [
+    'Gemini',
+    new GeminiAdapter(),
+    ['https://gemini.google.com/app/77aa11', 'https://gemini.google.com/app/77aa11?hl=de'],
+    ['https://gemini.google.com/app', 'https://gemini.google.com/'],
+  ],
+])('%s hasConversationId', (_name, adapter, conversationUrls, newChatUrls) => {
+  it.each(conversationUrls)('recognises %s as a conversation', (url) => {
+    expect(adapter.hasConversationId?.(url)).toBe(true);
+  });
+
+  it.each(newChatUrls)('recognises %s as a new-chat screen', (url) => {
+    expect(adapter.hasConversationId?.(url)).toBe(false);
+  });
+});

--- a/tests/shared/entity-map-migration.test.ts
+++ b/tests/shared/entity-map-migration.test.ts
@@ -1,4 +1,4 @@
-import { migrateEntityMap, loadEntityMap } from '../../src/shared/storage';
+import { migrateEntityMap, loadEntityMap, ownedEntries } from '../../src/shared/storage';
 
 /**
  * Chat sites create the conversation on the first send and rewrite the URL in
@@ -73,5 +73,65 @@ describe('migrateEntityMap', () => {
     await migrateEntityMap(CONVERSATION, CONVERSATION, { '[PERSON_1]': 'Peter Mayer' });
 
     expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+  it('leaves another draft\'s mappings on the shared new-chat key', async () => {
+    // Two tabs composing a first message. This session emitted [PERSON_1];
+    // [EMAIL_2] belongs to the other tab's draft.
+    store.pg_entity_maps = {
+      [NEW_CHAT]: {
+        '[PERSON_1]': 'Peter Mayer',
+        '[EMAIL_2]': 'someone-else@example-corp.test',
+      },
+    };
+    const inMemory = {
+      '[PERSON_1]': 'Peter Mayer',
+      '[EMAIL_2]': 'someone-else@example-corp.test',
+    };
+
+    await migrateEntityMap(
+      NEW_CHAT,
+      CONVERSATION,
+      ownedEntries(inMemory, new Set(['[PERSON_1]'])),
+    );
+
+    await expect(loadEntityMap(CONVERSATION)).resolves.toEqual({
+      '[PERSON_1]': 'Peter Mayer',
+    });
+    await expect(loadEntityMap(NEW_CHAT)).resolves.toEqual({
+      '[EMAIL_2]': 'someone-else@example-corp.test',
+    });
+});
+
+/**
+ * The "new chat" URL is a single key shared by every tab composing its first
+ * message, and a page session restores it on load. `ownedEntries` is what
+ * keeps one session from persisting or migrating another's originals.
+ */
+describe('ownedEntries', () => {
+  const MAP = {
+    '[PERSON_1]': 'Peter Mayer',
+    '[EMAIL_2]': 'peter@example-corp.test',
+    '[PHONE_3]': '+43 660 1234567',
+  };
+
+  it('keeps only the entries this session emitted', () => {
+    const owned = ownedEntries(MAP, new Set(['[PERSON_1]', '[PHONE_3]']));
+
+    expect(owned).toEqual({
+      '[PERSON_1]': 'Peter Mayer',
+      '[PHONE_3]': '+43 660 1234567',
+    });
+  });
+
+  it('returns nothing when the session emitted nothing', () => {
+    expect(ownedEntries(MAP, new Set())).toEqual({});
+  });
+
+  it('ignores tokens the session emitted that are no longer mapped', () => {
+    expect(ownedEntries(MAP, new Set(['[PERSON_1]', '[GONE_9]']))).toEqual({
+      '[PERSON_1]': 'Peter Mayer',
+    });
+  });
+
   });
 });

--- a/tests/shared/entity-map-migration.test.ts
+++ b/tests/shared/entity-map-migration.test.ts
@@ -1,0 +1,77 @@
+import { migrateEntityMap, loadEntityMap } from '../../src/shared/storage';
+
+/**
+ * Chat sites create the conversation on the first send and rewrite the URL in
+ * place. Mappings recorded while composing are filed under the transient
+ * "new chat" URL and must move to the conversation URL, or restoration is
+ * lost as soon as the page is reloaded.
+ */
+describe('migrateEntityMap', () => {
+  const NEW_CHAT = 'https://app.langdock.com/chat';
+  const CONVERSATION = 'https://app.langdock.com/chat/abc-123';
+
+  let store: Record<string, unknown>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = {};
+    (chrome.storage.local.get as jest.Mock).mockImplementation(async (key: string) => ({
+      [key]: store[key],
+    }));
+    (chrome.storage.local.set as jest.Mock).mockImplementation(async (patch: Record<string, unknown>) => {
+      Object.assign(store, patch);
+    });
+  });
+
+  it('moves pending mappings onto the conversation URL', async () => {
+    store.pg_entity_maps = { [NEW_CHAT]: { '[PERSON_1]': 'Peter Mayer' } };
+
+    await migrateEntityMap(NEW_CHAT, CONVERSATION, { '[PERSON_1]': 'Peter Mayer' });
+
+    await expect(loadEntityMap(CONVERSATION)).resolves.toEqual({ '[PERSON_1]': 'Peter Mayer' });
+    await expect(loadEntityMap(NEW_CHAT)).resolves.toEqual({});
+  });
+
+  it('merges into mappings the conversation already has', async () => {
+    store.pg_entity_maps = {
+      [NEW_CHAT]: { '[EMAIL_2]': 'peter@example-corp.test' },
+      [CONVERSATION]: { '[PERSON_1]': 'Peter Mayer' },
+    };
+
+    await migrateEntityMap(NEW_CHAT, CONVERSATION, { '[EMAIL_2]': 'peter@example-corp.test' });
+
+    await expect(loadEntityMap(CONVERSATION)).resolves.toEqual({
+      '[PERSON_1]': 'Peter Mayer',
+      '[EMAIL_2]': 'peter@example-corp.test',
+    });
+  });
+
+  it('leaves another tab’s pending mappings under the transient URL', async () => {
+    store.pg_entity_maps = {
+      [NEW_CHAT]: {
+        '[PERSON_1]': 'Peter Mayer',
+        '[PERSON_9]': 'Hans Gruber',
+      },
+    };
+
+    // Only this page session's entries move.
+    await migrateEntityMap(NEW_CHAT, CONVERSATION, { '[PERSON_1]': 'Peter Mayer' });
+
+    await expect(loadEntityMap(CONVERSATION)).resolves.toEqual({ '[PERSON_1]': 'Peter Mayer' });
+    await expect(loadEntityMap(NEW_CHAT)).resolves.toEqual({ '[PERSON_9]': 'Hans Gruber' });
+  });
+
+  it('does nothing when there is nothing to move', async () => {
+    store.pg_entity_maps = { [CONVERSATION]: { '[PERSON_1]': 'Peter Mayer' } };
+
+    await migrateEntityMap(NEW_CHAT, CONVERSATION, {});
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the URL did not actually change', async () => {
+    await migrateEntityMap(CONVERSATION, CONVERSATION, { '[PERSON_1]': 'Peter Mayer' });
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ui/de-anon-banner.test.ts
+++ b/tests/ui/de-anon-banner.test.ts
@@ -220,4 +220,35 @@ describe('attachDeAnonBanner', () => {
     expect(copiedText).not.toContain('[EMAIL_1]');
     expect(copiedText).toContain('[PHONE_1]');
   });
+
+  it('still attaches once content that resolves arrives later', () => {
+    const entityMap = new EntityMap({ '[PERSON_1]': 'Lukas Wagner' });
+    const responseElement = document.createElement('div');
+    document.body.append(responseElement);
+
+    // A streaming response inspected before any placeholder has arrived.
+    // Marking the element as handled here used to suppress the banner for
+    // good, so the reply never became revealable.
+    attachDeAnonBanner(responseElement, entityMap);
+    expect(document.querySelector('.pg-deanon-host')).toBeNull();
+    expect(responseElement.dataset.pgBanner).toBeUndefined();
+
+    responseElement.textContent = 'Reply about [PERSON_1]';
+    attachDeAnonBanner(responseElement, entityMap);
+
+    expect(document.querySelectorAll('.pg-deanon-host')).toHaveLength(1);
+    expect(responseElement.dataset.pgBanner).toBe('attached');
+  });
+
+  it('does not attach a second banner to the same response element', () => {
+    const entityMap = new EntityMap({ '[PERSON_1]': 'Lukas Wagner' });
+    const responseElement = document.createElement('div');
+    responseElement.textContent = 'Reply about [PERSON_1]';
+    document.body.append(responseElement);
+
+    attachDeAnonBanner(responseElement, entityMap);
+    attachDeAnonBanner(responseElement, entityMap);
+
+    expect(document.querySelectorAll('.pg-deanon-host')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Fixes #27.

Built on @peterhoneder's `fix/shared-restoration` branch — three of its four commits are cherry-picked here with authorship intact. Thanks for the diagnosis and the fix.

## The bug

`content-script.ts` captured its storage key once, at `document_start`:

```ts
const conversationUrl = window.location.href.split('?')[0];
```

Every supported site creates the conversation on the first send and rewrites the URL in place — a same-document navigation, so the content script is never re-run. Mappings recorded while composing on `claude.ai/new` stay filed under `https://claude.ai/new`, and after a reload of `/chat/<uuid>` nothing is found: the reply can no longer be turned back into the original values.

Two consequences the issue does not spell out: switching conversations without a reload carried the previous conversation's in-memory map into the next one, and the "new chat" key accumulated entries from every new chat ever started.

## What changed

`conversationUrl` becomes mutable, kept in step by a 500 ms poll plus `popstate`. Polling is the dependable option here — content scripts run in an isolated world, so patching `history.pushState` would never observe the page's own calls.

A new optional `hasConversationId(url)` on the adapter distinguishes the two cases. On the false → true transition the site has just created the conversation, so `migrateEntityMap` moves the mappings this page session produced onto the new key; only the supplied entries move, so a second tab composing its own new chat keeps its pending mappings. Any other change is a genuine conversation switch, and that conversation's stored mappings are adopted instead.

Two further fixes carried over from the same branch, both of which stopped the reveal banner from appearing:

- `ResponseObserver` disconnected an element's observer after the first debounce fire, so a reply arriving in bursts with pauses longer than 500 ms was only ever inspected up to the first pause.
- `attachDeAnonBanner` marked the element handled *before* checking whether anything was revealable, permanently suppressing the banner for any element first inspected while still empty.

## Two defects fixed on top

Both are in the ported code and are covered by tests:

**`d364f3c`** — `hasConversationId` is documented as optional, with adapters that omit it keeping the load-time URL for the page's lifetime. The watcher did not honour that: it adopted the stored map for whatever URL appeared next, even when the adapter could not say whether the conversation had changed. On an unrecognised site a route change need not mean a new conversation, and guessing drops mappings the current page can still reveal. All four supported hosts implement the hook, so this only affects the generic adapter and any site added later (#22, #26, #24).

**`92bae15`** — the per-element bookkeeping added alongside the persistent observers survived `stop()` while the observers it described were disconnected, so a later `start()` treated those elements as already watched and never observed them again. The added test fails without the fix.

## Not included

`peterhoneder@a041408` ("fix(storage): add new chat sites when upgrading") is an unrelated concern and is filed separately as #31, with a note on how it interacts with #19.

## Verification

New: `tests/shared/entity-map-migration.test.ts`, `tests/content/site-adapters/conversation-id.test.ts`, `tests/content/response-observer.test.ts`, plus additions to `tests/shared/storage.test.ts` and `tests/ui/de-anon-banner.test.ts`.

`tsc --noEmit`, 720 tests, and `node scripts/validate.js ci` all pass. Coverage is unit-level — the `/new` → `/chat/<uuid>` transition is exercised through the adapter URL matchers rather than against the live sites, so a manual pass through the issue's repro steps is worth doing before merge.
