### PR TITLE
Drop the lint script that has never had an ESLint to run

### DIFF
--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -107,7 +107,6 @@ This command does not download, prepare, or require large model assets. It runs 
 Optional checks:
 
 ```bash
-npm run lint
 npm run benchmark:openpii -- --regex-only
 ```
 

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -69,7 +69,7 @@ Model-free CI checks:
 npm run validate:ci
 ```
 
-This path is safe for pull requests and local pre-release checks. It runs Jest, Svelte checks, version alignment, Chrome permission checks, the privacy-boundary scan, Rust tests, and a model-free extension build. It does not download, prepare, or require large model assets. The current tree does not have a healthy ESLint setup, so lint is not part of this path yet.
+This path is safe for pull requests and local pre-release checks. It runs Jest, Svelte checks, version alignment, Chrome permission checks, the privacy-boundary scan, Rust tests, and a model-free extension build. It does not download, prepare, or require large model assets. There is no ESLint setup in this tree, so no lint step runs.
 
 Release-strict checks with prepared BardsAI assets:
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "benchmark:openpii": "node scripts/run-openpii-benchmark.js",
     "benchmark:openpii:download": "node scripts/download-openpii-dataset.js",
     "benchmark:openpii:build": "node scripts/build-openpii-corpus.js",
-    "lint": "eslint src/ --ext .ts",
     "clean": "rm -rf dist crate/pkg crate/target",
     "launch-chrome-without-webgpu-mac": "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --user-data-dir=/private/tmp/pg-cpu-chrome --disable-features=WebGPU  --disable-gpu"
   },


### PR DESCRIPTION
`npm run lint` has failed with `eslint: command not found` since the initial public release. The script is in `package.json`, but ESLint has never been a devDependency and the repo carries no config — `git log -S eslint -- package.json` returns only the initial commit.

`docs/developer/building.md` listed it under optional checks, so a contributor following the docs hit the failure. That line goes too, and the note in `docs/developer/releasing.md` is reworded to describe the tree as it is rather than as a step not yet wired up.

Setting ESLint up properly is a separate decision — picking a rule set and absorbing the churn of a first pass over `src/` — so this only removes what does not work. `node scripts/validate.js ci` passes (695 tests); it never invoked lint.