### PR TITLE
Add newly supported chat sites to existing users' settings on upgrade

### DIFF
--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,6 +1,6 @@
 import type { Settings, FeedbackEntry, NerModelKey, NerProviderMode, NerWebGpuDtype, GroupName, AllowlistEntry, BlocklistEntry, CancelDetectionBehavior, LocalAiUnloadTimeoutMs } from './message-types';
 import { ENTITY_TYPES } from './message-types';
-import { DEFAULT_SETTINGS, LOCAL_AI_UNLOAD_TIMEOUT_CHOICES, NER_WEBGPU_DTYPE_CHOICES, runtimeNerModelKey } from './constants';
+import { DEFAULT_CURATED_URLS, DEFAULT_SETTINGS, LOCAL_AI_UNLOAD_TIMEOUT_CHOICES, NER_WEBGPU_DTYPE_CHOICES, runtimeNerModelKey } from './constants';
 import { GROUP_NAMES, GROUP_DEFAULT_ON } from './category-groups';
 
 const SETTINGS_KEY = 'pg_settings';
@@ -139,6 +139,22 @@ function normalizeSettings(raw: unknown): Settings {
   if (typeof settings.autoWarmLocalAiOnActiveSupportedPage !== 'boolean') {
     settings.autoWarmLocalAiOnActiveSupportedPage = DEFAULT_SETTINGS.autoWarmLocalAiOnActiveSupportedPage;
   }
+  // Union the stored list with the current defaults so a chat site added in a
+  // later release reaches users who already have settings. A stored array
+  // otherwise shadows the defaults for good: `isSupportedPageUrl` never
+  // matches the new host, so the toolbar icon stays inactive and Local AI
+  // warm-up is gated off there, while the content script — matched from the
+  // manifest rather than from settings — still runs.
+  //
+  // This only ever adds. Entries the defaults do not know about survive, so
+  // additions keep working if the list becomes user-editable (#19), but
+  // nothing is ever dropped: a default a user removed would come back, and a
+  // host retired from DEFAULT_CURATED_URLS stays curated for everyone who
+  // already has settings. Both cases need a record of which defaults a user
+  // has been offered, worth adding alongside the UI that edits the list.
+  settings.curatedUrls = Array.isArray(settings.curatedUrls)
+    ? [...new Set([...settings.curatedUrls, ...DEFAULT_CURATED_URLS])]
+    : [...DEFAULT_CURATED_URLS];
   return settings;
 }
 

--- a/tests/shared/storage.test.ts
+++ b/tests/shared/storage.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SETTINGS } from '../../src/shared/constants';
+import { DEFAULT_CURATED_URLS, DEFAULT_SETTINGS } from '../../src/shared/constants';
 import { loadSettings, saveSettings } from '../../src/shared/storage';
 
 describe('settings storage', () => {
@@ -187,6 +187,64 @@ describe('settings storage', () => {
         localAiUnloadTimeoutMs: null,
         keepLocalAiLoadedWhileActive: false,
         autoWarmLocalAiOnActiveSupportedPage: true,
+      }),
+    });
+  });
+
+  test('adds newly supported chat hosts to a curatedUrls list stored before they existed', async () => {
+    // Settings written by an older install, holding only the hosts that were
+    // curated back then. Without reconciling, the stored array shadows the
+    // defaults for good and a site added in a later release never activates
+    // the toolbar icon or Local AI warm-up for this user.
+    (chrome.storage.local.get as jest.Mock).mockResolvedValueOnce({
+      pg_settings: {
+        ...DEFAULT_SETTINGS,
+        curatedUrls: ['https://chat.openai.com', 'https://claude.ai'],
+      },
+    });
+
+    const settings = await loadSettings();
+
+    expect(settings.curatedUrls).toEqual(expect.arrayContaining([...DEFAULT_CURATED_URLS]));
+  });
+
+  test('keeps stored curated URLs the defaults do not know about, without duplicating defaults', async () => {
+    (chrome.storage.local.get as jest.Mock).mockResolvedValueOnce({
+      pg_settings: {
+        ...DEFAULT_SETTINGS,
+        curatedUrls: ['https://claude.ai', 'https://chat.example-corp.test'],
+      },
+    });
+
+    const settings = await loadSettings();
+
+    expect(settings.curatedUrls).toEqual(expect.arrayContaining([...DEFAULT_CURATED_URLS]));
+    expect(settings.curatedUrls).toContain('https://chat.example-corp.test');
+    expect(new Set(settings.curatedUrls).size).toBe(settings.curatedUrls.length);
+  });
+
+  test('falls back to the default curated URLs when the stored value is not an array', async () => {
+    (chrome.storage.local.get as jest.Mock).mockResolvedValueOnce({
+      pg_settings: { ...DEFAULT_SETTINGS, curatedUrls: 'https://claude.ai' },
+    });
+
+    const settings = await loadSettings();
+
+    expect(settings.curatedUrls).toEqual([...DEFAULT_CURATED_URLS]);
+    // A copy, so nothing downstream can mutate the shared default list.
+    expect(settings.curatedUrls).not.toBe(DEFAULT_CURATED_URLS);
+  });
+
+  test('writes the reconciled curated URL list back when settings are saved', async () => {
+    (chrome.storage.local.get as jest.Mock).mockResolvedValueOnce({
+      pg_settings: { ...DEFAULT_SETTINGS, curatedUrls: ['https://claude.ai'] },
+    });
+
+    await saveSettings({ enabled: true });
+
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      pg_settings: expect.objectContaining({
+        curatedUrls: expect.arrayContaining([...DEFAULT_CURATED_URLS]),
       }),
     });
   });


### PR DESCRIPTION
Fixes #31.

Takes @peterhoneder's `a041408` ("fix(storage): add new chat sites when upgrading"), which was deliberately left out of #33 as an unrelated concern. Thanks for spotting it. Rewritten rather than cherry-picked, for the additions below.

## The bug

`normalizeSettings` merged stored settings over `DEFAULT_SETTINGS` and left `curatedUrls` alone. Once a user's settings had been written to `chrome.storage`, the stored array shadowed `DEFAULT_CURATED_URLS` for good — so a chat site added to the defaults in a later version only ever reached fresh installs.

For an existing user on a newly supported site that means `isSupportedPageUrl` (`src/background/service-worker.ts:105`) returns false, so the toolbar icon stays inactive, and the active-tab check at `src/background/service-worker.ts:738` returns false, so Local AI warm-up is gated off. The content script still runs — its matches come from `manifest.json`, not from settings — so it presents as the extension being quietly half-on rather than as a clean failure.

What makes it permanent is the `onInstalled` handler (`src/background/service-worker.ts:661`):

```ts
chrome.runtime.onInstalled.addListener(async () => {
  const settings = await loadSettings();
  await saveSettings(settings);
```

That fires on update as well as install, so every release read the stale list back and wrote it out again untouched.

Nothing is broken today: `DEFAULT_CURATED_URLS` has not changed since the setting was introduced, so every stored list happens to match. It becomes real the moment the list grows, which is what #22 (Perplexity), #26 (langdock) and #24 would each do.

## What changed

On load, union the stored list with the current defaults:

```ts
settings.curatedUrls = Array.isArray(settings.curatedUrls)
  ? [...new Set([...settings.curatedUrls, ...DEFAULT_CURATED_URLS])]
  : [...DEFAULT_CURATED_URLS];
```

`normalizeSettings` runs on the write path too, so the same `onInstalled` handler that used to entrench the stale list now persists the reconciled one. An existing user picks up a newly supported site when they take the release, rather than lazily. The added save-path test covers that path.

## On the question #31 left open

The issue asked whether to take the union now or record which defaults a user has already been offered, so that deliberate removals stick once #19 makes the list editable.

This takes the union. Nothing in the options or popup writes `curatedUrls` today, so a record of offered defaults would be state that nothing produces — machinery for a UI that does not exist yet. The union is also not a dead end for #19: entries the defaults do not know about survive it, so *adding* a custom URL works unchanged.

What the union cannot do is drop anything, in either direction: a default a user removed would return on the next load, and a host retired from `DEFAULT_CURATED_URLS` would stay curated for everyone who already has settings. Neither is a regression — the frozen snapshot behaved the same way — and both need the same record of offered defaults. The comment in `normalizeSettings` records this where the next person will meet it.

## Two additions on top of `a041408`

- The non-array fallback copies the defaults (`[...DEFAULT_CURATED_URLS]`) instead of letting `settings.curatedUrls` alias the module constant, as it did whenever nothing was stored. Any downstream mutation would otherwise have edited the defaults for the whole process. Pinned by a test.
- A fourth test covering the `saveSettings` path, since reconciliation on write is what makes the fix land on update rather than per-load.

## Verification

Four tests added to `tests/shared/storage.test.ts`. All four fail with the `storage.ts` change stashed — checked, so none of them are vacuous.

`npm test` (738 tests, 67 suites), `tsc --noEmit`, `npm run check:svelte` (760 files, 0 errors) and `node scripts/validate.js ci` all pass locally. There is no GitHub Actions workflow in this repo, so none of that runs as a PR check.

Coverage is unit-level against `normalizeSettings`. The upgrade path itself — an older settings blob in a real profile picking up a site added later — is not exercised, and cannot be until the defaults actually grow; the first PR that adds a site is where that is worth a manual check with a pre-existing profile.
