### PR TITLE
fix(ner): place detected spans by token offset instead of text search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The project follows public beta release notes for `0.x` versions.
 
 ## Unreleased
 
-- Fixed Local AI marking the wrong text in a paste, and missing most of a long one. Detected values were located by searching the paste for each fragment the model returned, so a fragment that occurs more than once could be marked at the wrong occurrence, and the surrounding words could be swept in with it. Positions now come from the model's own tokens. Long text was also split by character count rather than by how much the model can read at once, so roughly the last two thirds of a long paste was never scanned; it is now split by what the model actually reads, and all of it is checked.
+- Fixed Local AI marking the wrong text in a paste, and missing most of a long one. Detected values were located by searching the paste for each fragment the model returned, so a fragment that occurs more than once could be marked at the wrong occurrence, and the surrounding words could be swept in with it. Positions now come from the model's own tokens. Long text was also split by character count rather than by how much the model can read at once, so roughly the last two thirds of a long paste was never scanned; it is now split by what the model actually reads, including a token-limit check on the final inputs when alignment needs a fallback.
+
+- Hardened Local AI span recovery: identifier repairs preserve confident detections, email-domain repairs keep adjacent companies separate, and literal tokenizer control strings no longer shift highlights onto the wrong occurrence. Multiword confidence now considers each word instead of only the opening word.
 
 ## [0.4.2] - Public Beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The project follows public beta release notes for `0.x` versions.
 
 ## Unreleased
 
+- Fixed Local AI marking the wrong text in a paste, and missing most of a long one. Detected values were located by searching the paste for each fragment the model returned, so a fragment that occurs more than once could be marked at the wrong occurrence, and the surrounding words could be swept in with it. Positions now come from the model's own tokens. Long text was also split by character count rather than by how much the model can read at once, so roughly the last two thirds of a long paste was never scanned; it is now split by what the model actually reads, and all of it is checked.
+
 ## [0.4.2] - Public Beta
 
 - Fixed replaced values being forgotten once a new chat got its own address. Starting a chat, pasting something that was replaced and sending it moves the page from the "new chat" screen to the conversation's own URL, and the replacements stayed filed under the screen you left — so after a reload the reply could no longer be turned back into your original values. They now move with the conversation, and switching between existing chats without a page reload loads the right conversation's replacements.

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -535,6 +535,44 @@ function tokenLimitFor(tokenizer: NerTokenizerLike): number {
  * word in half and no source character is dropped: alignTokensToText places
  * every content token, and consecutive chunks are joined end-to-start.
  */
+/**
+ * Character offset a chunk beginning at 'index' should open on.
+ *
+ * 'index' can itself be an unplaced token, so scan forward for the first placed
+ * one. That offset is never past the previous chunk's end — the previous
+ * boundary is a placed token at or after 'index' — so the chunks still meet.
+ */
+function chunkStartChar(ranges: readonly (TokenCharRange | null)[], index: number): number {
+  for (let i = index; i < ranges.length; i += 1) {
+    const range = ranges[i];
+    if (range) return range.start;
+  }
+  return 0;
+}
+
+/**
+ * Index of the token a chunk should close on, given the end its budget allows.
+ *
+ * A chunk is cut at character offsets, so the boundary has to sit on a token the
+ * aligner actually placed. Preferring the last placed token at or before the
+ * budget keeps the chunk within it; only when an unplaced run swallows the whole
+ * window do we step past the budget instead, which costs a few encoder positions
+ * but never drops those characters from every chunk.
+ */
+function chunkBoundaryIndex(
+  ranges: readonly (TokenCharRange | null)[],
+  tokenStart: number,
+  tokenEnd: number
+): number {
+  for (let i = Math.min(tokenEnd, ranges.length - 1); i > tokenStart; i -= 1) {
+    if (ranges[i]) return i;
+  }
+  for (let i = tokenEnd + 1; i < ranges.length; i += 1) {
+    if (ranges[i]) return i;
+  }
+  return ranges.length;
+}
+
 export function chunkTextByTokens(
   text: string,
   tokenizer: NerTokenizerLike,
@@ -555,13 +593,12 @@ export function chunkTextByTokens(
   }
 
   const ranges = alignTokensToText(text, pieces);
-  const placed = ranges.filter((range): range is TokenCharRange => range !== null);
-  if (placed.length === 0) return null;
+  if (!ranges.some((range) => range !== null)) return null;
 
   // sanity gate: if we could not place most of the tokens we do not trust
   // the boundaries either, and the caller should fall back to character chunks.
   if (alignmentCoverage(ranges, pieces) < MIN_ALIGNMENT_COVERAGE) return null;
-  if (placed.length <= maxTokens) {
+  if (pieces.length <= maxTokens) {
     return [
       {
         text,
@@ -576,8 +613,12 @@ export function chunkTextByTokens(
   const chunks: NerTextChunk[] = [];
   let tokenStart = 0;
 
-  while (tokenStart < placed.length) {
-    const tokenEnd = Math.min(placed.length, tokenStart + maxTokens);
+  // The budget counts every tokenizer piece, not only the ones we could place.
+  // An unplaced piece — an <unk>, a dropped or zero-width character — still
+  // occupies an encoder position, so measuring the chunk by placed tokens alone
+  // would let it overrun the very limit this function exists to respect.
+  while (tokenStart < pieces.length) {
+    const tokenEnd = Math.min(pieces.length, tokenStart + maxTokens);
     // Close each chunk at the *next* chunk's first token rather than at its own
     // last one, so consecutive chunks meet with no gap. Characters between
     // tokens have no boundary of their own — whitespace, but also anything the
@@ -586,8 +627,9 @@ export function chunkTextByTokens(
     // silently unscanned. Every character lands in at least one chunk; with
     // overlapTokens > 0 the shared region is deliberately in two, and
     // mergeOverlappingNerSpans dedupes the results.
-    const startChar = tokenStart === 0 ? 0 : placed[tokenStart].start;
-    const endChar = tokenEnd >= placed.length ? text.length : placed[tokenEnd].start;
+    const boundary = tokenEnd >= pieces.length ? pieces.length : chunkBoundaryIndex(ranges, tokenStart, tokenEnd);
+    const startChar = tokenStart === 0 ? 0 : chunkStartChar(ranges, tokenStart);
+    const endChar = boundary >= pieces.length ? text.length : ranges[boundary]!.start;
 
     chunks.push({
       text: text.slice(startChar, endChar),
@@ -597,8 +639,8 @@ export function chunkTextByTokens(
       endByte: byteLength(text.slice(0, endChar)),
     });
 
-    if (tokenEnd >= placed.length) break;
-    tokenStart = Math.max(tokenStart + 1, tokenEnd - overlapTokens);
+    if (boundary >= pieces.length) break;
+    tokenStart = Math.max(tokenStart + 1, boundary - overlapTokens);
   }
 
   return chunks;

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -440,6 +440,14 @@ function chunkBoundaryEnd(text: string, start: number, targetEnd: number, maxChu
   return targetEnd;
 }
 
+function codePointBoundaryAtOrBefore(text: string, index: number): number {
+  const current = text.charCodeAt(index);
+  const previous = text.charCodeAt(index - 1);
+  return current >= 0xdc00 && current <= 0xdfff && previous >= 0xd800 && previous <= 0xdbff
+    ? index - 1
+    : index;
+}
+
 export function chunkTextForNer(
   text: string,
   options: NerChunkingOptions = {}
@@ -461,7 +469,10 @@ export function chunkTextForNer(
 
   while (startChar < text.length) {
     const targetEnd = Math.min(text.length, startChar + maxChunkChars);
-    const endChar = chunkBoundaryEnd(text, startChar, targetEnd, maxChunkChars);
+    const firstCodePointEnd = startChar + String.fromCodePoint(text.codePointAt(startChar)!).length;
+    const endChar = Math.max(firstCodePointEnd, codePointBoundaryAtOrBefore(
+      text, chunkBoundaryEnd(text, startChar, targetEnd, maxChunkChars)
+    ));
     const startByte = byteLength(text.slice(0, startChar));
     const endByte = byteLength(text.slice(0, endChar));
     chunks.push({
@@ -473,7 +484,7 @@ export function chunkTextForNer(
     });
 
     if (endChar >= text.length) break;
-    startChar = Math.max(startChar + 1, endChar - boundedOverlap);
+    startChar = codePointBoundaryAtOrBefore(text, Math.max(firstCodePointEnd, endChar - boundedOverlap));
   }
 
   return chunks;
@@ -560,7 +571,7 @@ export function chunkTextByTokens(
     return null;
   }
 
-  const ranges = alignTokensToText(text, pieces);
+  const ranges = alignTokensToText(text, pieces, { addSpecialTokens: false });
   if (!ranges.some((range) => range !== null)) return null;
 
   if (alignmentCoverage(ranges, pieces) < MIN_ALIGNMENT_COVERAGE) return null;
@@ -602,6 +613,37 @@ export function chunkTextByTokens(
   }
 
   return chunks;
+}
+
+/** Retokenize the exact input: slicing and failed alignment can change its budget. */
+function fitChunkToTokenBudget(
+  chunk: NerTextChunk,
+  tokenizer: NerTokenizerLike,
+  maxPositions: number
+): NerTextChunk[] {
+  const pieces = safeTokenize(tokenizer, chunk.text);
+  if (!pieces) throw new Error('Unable to verify the Local AI input token limit.');
+  if (pieces.length <= maxPositions) return [chunk];
+
+  const characters = Array.from(chunk.text);
+  if (characters.length < 2) {
+    throw new Error('A source character exceeds the Local AI input token limit.');
+  }
+  const middle = Math.floor(characters.length / 2);
+  const overlap = Math.min(Math.floor(DEFAULT_NER_CHUNK_OVERLAP_CHARS / 2), Math.floor(characters.length / 4));
+  const leftEnd = characters.slice(0, middle + overlap).join('').length;
+  const rightStart = characters.slice(0, middle - overlap).join('').length;
+
+  return [[0, leftEnd], [rightStart, chunk.text.length]].flatMap(([start, end]) => {
+    const part: NerTextChunk = {
+      text: chunk.text.slice(start, end),
+      startChar: chunk.startChar + start,
+      endChar: chunk.startChar + end,
+      startByte: chunk.startByte + byteLength(chunk.text.slice(0, start)),
+      endByte: chunk.startByte + byteLength(chunk.text.slice(0, end)),
+    };
+    return fitChunkToTokenBudget(part, tokenizer, maxPositions);
+  });
 }
 
 function shiftSpanToOriginalText(span: PiiSpan, chunk: NerTextChunk): PiiSpan {
@@ -1101,7 +1143,7 @@ const INTRA_RUN_LOOKBACK_SPANS = 3;
  * When that middle falls under its own threshold, both ends are redacted and
  * 'tester' of 't.tester@example.invalid' is left in the clear.
  */
-function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
+function closeIntraRunGaps(text: string, spans: PiiSpan[], modelKey: NerModelKey): PiiSpan[] {
   const out: PiiSpan[] = [];
 
   for (const span of spans) {
@@ -1114,6 +1156,11 @@ function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
       // An empty bridge counts: the two halves can end up flush.
       if (!isBridgeableGap(sliceTextByByteOffsets(text, candidate.end, span.start))) continue;
 
+      // Same-type evidence may support the whole repair, but a failing repair
+      // must never delete a passing differently labelled middle.
+      const score = Math.max(candidate.score, span.score);
+      if (!passesNerThreshold({ ...candidate, score }, modelKey)) continue;
+      candidate.score = score;
       candidate.end = span.end;
       candidate.text = sliceTextByByteOffsets(text, candidate.start, candidate.end);
       mergedInto = i;
@@ -1136,7 +1183,7 @@ function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
   return out;
 }
 
-function stitchEmailDomains(text: string, spans: PiiSpan[]): PiiSpan[] {
+function stitchEmailDomains(text: string, spans: PiiSpan[], modelKey: NerModelKey): PiiSpan[] {
   const stitched: PiiSpan[] = [];
 
   for (const span of spans) {
@@ -1149,9 +1196,20 @@ function stitchEmailDomains(text: string, spans: PiiSpan[]): PiiSpan[] {
     ) {
       const gap = sliceTextByByteOffsets(text, previous.end, span.start);
       const joinsAddress = gap === '@' || (gap === '' && previous.text.endsWith('@'));
-      if (joinsAddress) {
-        previous.end = span.end;
+      const domain = /^[\p{L}\p{N}](?:[\p{L}\p{N}.\-]*[\p{L}\p{N}])?/u.exec(span.text)?.[0];
+      if (joinsAddress && domain && passesNerThreshold(previous, modelKey)) {
+        previous.end = span.start + byteLength(domain);
         previous.text = sliceTextByByteOffsets(text, previous.start, previous.end);
+        const remainder = span.text.slice(domain.length);
+        const leadingSpace = /^\s*/u.exec(remainder)![0].length;
+        const remainingText = remainder.slice(leadingSpace);
+        if (/[\p{L}\p{N}]/u.test(remainingText)) {
+          stitched.push({
+            ...span,
+            start: previous.end + byteLength(remainder.slice(0, leadingSpace)),
+            text: remainingText,
+          });
+        }
         continue;
       }
     }
@@ -1169,9 +1227,9 @@ function stitchEmailDomains(text: string, spans: PiiSpan[]): PiiSpan[] {
  * 'item.index' addresses it directly. Grouping is by entity type and source
  * adjacency, not the model's BIO prefixes.
  *
- * A group scores from its opening token ('first' strategy): confidence decays across
- * continuation pieces -- 'firstName.lastName@' scores [0.999, 0.999, 0.473, 0.670,
- * 0.586, 0.631] -- so averaging would drop a genuine address under the email gate.
+ * Use the opening score within each whitespace-delimited word, then average the
+ * word scores. Email continuation scores decay, but a weak opening word must not
+ * determine the confidence of an entire multiword name or organization.
  */
 export function alignedTokensToSpans(
   text: string,
@@ -1197,7 +1255,7 @@ export function alignedTokensToSpans(
   predictions.sort((a, b) => a.range.start - b.range.start || a.range.end - b.range.end);
 
   const grouped: PiiSpan[] = [];
-  let current: { prediction: AlignedTokenPrediction; end: number } | null = null;
+  let current: { prediction: AlignedTokenPrediction; end: number; wordScores: number[] } | null = null;
 
   const flush = (): void => {
     if (!current) return;
@@ -1209,7 +1267,7 @@ export function alignedTokensToSpans(
       start: stringIndexToByteOffset(text, range.start),
       end: stringIndexToByteOffset(text, range.end),
       entity_type: current.prediction.entityType,
-      score: current.prediction.score,
+      score: current.wordScores.reduce((sum, score) => sum + score, 0) / current.wordScores.length,
       text: text.slice(range.start, range.end),
       source: 'ner',
       nerRawLabel: current.prediction.rawLabel,
@@ -1219,7 +1277,7 @@ export function alignedTokensToSpans(
 
   for (const prediction of predictions) {
     if (!current) {
-      current = { prediction, end: prediction.range.end };
+      current = { prediction, end: prediction.range.end, wordScores: [prediction.score] };
       continue;
     }
 
@@ -1229,16 +1287,17 @@ export function alignedTokensToSpans(
       : '';
 
     if (sameType && prediction.range.start >= current.prediction.range.start && isJoinableGap(gap)) {
+      if (/\s/u.test(gap)) current.wordScores.push(prediction.score);
       current.end = Math.max(current.end, prediction.range.end);
       continue;
     }
 
     flush();
-    current = { prediction, end: prediction.range.end };
+    current = { prediction, end: prediction.range.end, wordScores: [prediction.score] };
   }
   flush();
 
-  return stitchEmailDomains(text, closeIntraRunGaps(text, grouped));
+  return stitchEmailDomains(text, closeIntraRunGaps(text, grouped, modelKey), modelKey);
 }
 
 export function transformerOutputToSpans(
@@ -1359,20 +1418,20 @@ export function createTransformersNerProvider(
   }
 
   function planChunks(text: string, tokenizer: NerTokenizerLike | undefined): NerTextChunk[] {
-    if (tokenizer) {
-      const tokenChunks = chunkTextByTokens(text, tokenizer, {
-        maxTokens: tokenLimitFor(tokenizer),
-      });
-      if (tokenChunks) return tokenChunks;
-      debugLog('[PG:ner] detect: token chunking unavailable, falling back to characters');
-    }
-
-    // No tokenizer to measure with, so cap on characters pessimistically rather
-    // than letting a long paste run past the encoder's 512 positions unseen.
-    return chunkTextForNer(text, {
+    const tokenChunks = tokenizer ? chunkTextByTokens(text, tokenizer, {
+      maxTokens: tokenLimitFor(tokenizer),
+    }) : null;
+    const chunks = tokenChunks ?? chunkTextForNer(text, {
       ...chunking,
       maxChunkChars: Math.min(chunking?.maxChunkChars ?? MAX_TEXT_LENGTH, FALLBACK_MAX_CHUNK_CHARS),
     });
+    if (!tokenizer) return chunks;
+
+    // Alignment is optional for choosing boundaries, never for enforcing the
+    // encoder limit. A tokenization failure propagates as Local AI unavailable.
+    return chunks.flatMap((chunk) => fitChunkToTokenBudget(
+      chunk, tokenizer, tokenLimitFor(tokenizer) + SPECIAL_TOKEN_BUDGET
+    ));
   }
 
   async function detectChunked(

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -1144,6 +1144,79 @@ const EMAIL_DOMAIN_TAIL_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
   'MISC',
 ]);
 
+/**
+ * Longest mislabelled stretch we will bridge inside a single identifier.
+ */
+const MAX_INTRA_RUN_GAP_CHARS = 16;
+
+/**
+ * Characters that can sit *inside* one identifier.
+ *
+ * Deliberately excludes every separator -- whitespace, comma, bracket, slash,
+ * semicolon -- so a bridge can only ever close a gap within one value, never
+ * reach across the boundary between two of them.
+ */
+const INTRA_RUN_BRIDGE_PATTERN = /^[\p{L}\p{N}_.\-+@]*$/u;
+
+function isBridgeableGap(bridge: string): boolean {
+  return bridge.length <= MAX_INTRA_RUN_GAP_CHARS && INTRA_RUN_BRIDGE_PATTERN.test(bridge);
+}
+
+/** How far back a bridge may reach for the span it rejoins. */
+const INTRA_RUN_LOOKBACK_SPANS = 3;
+
+/**
+ * Rejoin same-type spans that a mislabelled slice split apart mid-identifier.
+ *
+ * Grouping already bridges an unlabelled gap, but the model sometimes drops a
+ * different label into the middle instead, and that middle span then falls under
+ * its own threshold. Left split, the anonymizer redacts both ends and publishes
+ * the middle in the clear: 't.tester@example.invalid' becomes a redacted 't.',
+ * an exposed 'tester', and a redacted '@example.invalid'.
+ *
+ * The bridge must be identifier interior only. An earlier form asked merely for
+ * no whitespace, which also joined 'a@b.example,c@d.example' and two people
+ * written 'Mueller,Schmidt' into one span, giving one placeholder for two
+ * distinct values.
+ */
+function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
+  const out: PiiSpan[] = [];
+
+  for (const span of spans) {
+    let mergedInto = -1;
+
+    for (let i = out.length - 1; i >= 0 && i >= out.length - INTRA_RUN_LOOKBACK_SPANS; i -= 1) {
+      const candidate = out[i];
+      if (candidate.entity_type !== span.entity_type || candidate.end > span.start) continue;
+
+      // An empty bridge counts: completing partial words can leave two halves of
+      // one identifier flush against each other with the mislabelled slice
+      // overlapping them both.
+      if (!isBridgeableGap(sliceTextByByteOffsets(text, candidate.end, span.start))) continue;
+
+      candidate.end = span.end;
+      candidate.text = sliceTextByByteOffsets(text, candidate.start, candidate.end);
+      mergedInto = i;
+      break;
+    }
+
+    if (mergedInto === -1) {
+      out.push(span);
+      continue;
+    }
+
+    // Anything the merge swallowed is no longer its own span.
+    const absorber = out[mergedInto];
+    out.splice(
+      mergedInto + 1,
+      out.length - mergedInto - 1,
+      ...out.slice(mergedInto + 1).filter((other) => other.end > absorber.end)
+    );
+  }
+
+  return out;
+}
+
 function stitchEmailDomains(text: string, spans: PiiSpan[]): PiiSpan[] {
   const stitched: PiiSpan[] = [];
 
@@ -1249,7 +1322,7 @@ export function alignedTokensToSpans(
   }
   flush();
 
-  return stitchEmailDomains(text, grouped);
+  return stitchEmailDomains(text, closeIntraRunGaps(text, grouped));
 }
 
 export function transformerOutputToSpans(

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -65,16 +65,10 @@ export type TokenClassificationItem = {
   entity_group?: string;
   start?: number;
   end?: number;
-  /**
-   * Position of this token in the tokenizer's 'input_ids'. Present only for raw
-   * output. It is the join key back onto the offset table containing start and end.
-   */
+  /** Index into 'input_ids'; the join key onto the offset table. Raw output only. */
   index?: number;
 };
 
-/**
- * The slice of 'PreTrainedTokenizer'
- */
 export interface NerTokenizerLike {
   tokenize(text: string, options?: { add_special_tokens?: boolean }): string[];
   readonly model_max_length?: number;
@@ -121,13 +115,7 @@ type TransformersModule = {
   ) => Promise<TokenClassificationPipeline>;
 };
 
-/**
- * A navigator-like object that may expose WebGPU (optional).
- *
- * 'Partial<Navigator>' rather than an extension of it: the offscreen document's
- * navigator is typed from whichever DOM lib is in scope, and only the members
- * read here matter.
- */
+/** 'Partial<Navigator>': the offscreen document's DOM lib varies, and only 'gpu' is read. */
 type NavigatorWithWebGpu = Partial<Navigator> & {
   gpu?: {
     requestAdapter?: () => Promise<unknown>;
@@ -187,15 +175,9 @@ const REQUIRED_RUNTIME_ASSETS = [
 
 export const DEFAULT_NER_CHUNK_OVERLAP_CHARS = 256;
 
-/**
- * Token budget per chunk.
- */
 export const DEFAULT_NER_MAX_TOKENS_PER_CHUNK = 480;
 export const DEFAULT_NER_CHUNK_OVERLAP_TOKENS = 64;
 
-/**
- * Character ceiling used when no tokenizer is available to chunk by token.
- */
 export const FALLBACK_MAX_CHUNK_CHARS = 800;
 
 // Distilbert-uncased + AI4Privacy emits softer scores than typical NER models
@@ -502,14 +484,10 @@ export interface NerTokenChunkingOptions {
   overlapTokens?: number;
 }
 
-/**
- * Below this share of placed tokens we stop trusting the offset table and fall
- * back to the legacy search, which is less accurate but degrades visibly rather
- * than silently pointing spans at the wrong words.
- */
+/** Below this share of placed tokens, fall back to the legacy search. */
 export const MIN_ALIGNMENT_COVERAGE = 0.8;
 
-/** Positions reserved for the post-processor's `<s>` / `</s>` (or `[CLS]` / `[SEP]`). */
+/** Positions reserved for '<s>' / '</s>' (or '[CLS]' / '[SEP]'). */
 const SPECIAL_TOKEN_BUDGET = 2;
 
 function safeTokenize(tokenizer: NerTokenizerLike, text: string): string[] | null {
@@ -531,20 +509,11 @@ function tokenLimitFor(tokenizer: NerTokenizerLike): number {
 }
 
 /**
- * Split text on token boundaries so no chunk can exceed the encoder's
- * position limit.
- *
- * Boundaries are taken from the aligner's char ranges, so a chunk never cuts a
- * word in half and no source character is dropped: alignTokensToText places
- * every content token, and consecutive chunks are joined end-to-start.
+ * Split text on token boundaries so no chunk exceeds the encoder's position limit.
+ * Boundaries come from the aligner, so no chunk cuts a word and no character is
+ * dropped between them.
  */
-/**
- * Character offset a chunk beginning at 'index' should open on.
- *
- * 'index' can itself be an unplaced token, so scan forward for the first placed
- * one. That offset is never past the previous chunk's end — the previous
- * boundary is a placed token at or after 'index' — so the chunks still meet.
- */
+/** 'index' may itself be unplaced, so scan forward for the first placed token. */
 function chunkStartChar(ranges: readonly (TokenCharRange | null)[], index: number): number {
   for (let i = index; i < ranges.length; i += 1) {
     const range = ranges[i];
@@ -554,13 +523,9 @@ function chunkStartChar(ranges: readonly (TokenCharRange | null)[], index: numbe
 }
 
 /**
- * Index of the token a chunk should close on, given the end its budget allows.
- *
- * A chunk is cut at character offsets, so the boundary has to sit on a token the
- * aligner actually placed. Preferring the last placed token at or before the
- * budget keeps the chunk within it; only when an unplaced run swallows the whole
- * window do we step past the budget instead, which costs a few encoder positions
- * but never drops those characters from every chunk.
+ * The boundary must sit on a placed token. Taking the last one at or before the
+ * budget keeps the chunk within it; only an unplaced run filling the whole window
+ * makes us step past, which costs a few positions but drops no characters.
  */
 function chunkBoundaryIndex(
   ranges: readonly (TokenCharRange | null)[],
@@ -598,8 +563,6 @@ export function chunkTextByTokens(
   const ranges = alignTokensToText(text, pieces);
   if (!ranges.some((range) => range !== null)) return null;
 
-  // sanity gate: if we could not place most of the tokens we do not trust
-  // the boundaries either, and the caller should fall back to character chunks.
   if (alignmentCoverage(ranges, pieces) < MIN_ALIGNMENT_COVERAGE) return null;
   if (pieces.length <= maxTokens) {
     return [
@@ -616,20 +579,12 @@ export function chunkTextByTokens(
   const chunks: NerTextChunk[] = [];
   let tokenStart = 0;
 
-  // The budget counts every tokenizer piece, not only the ones we could place.
-  // An unplaced piece — an <unk>, a dropped or zero-width character — still
-  // occupies an encoder position, so measuring the chunk by placed tokens alone
-  // would let it overrun the very limit this function exists to respect.
+  // Budget in every piece, not just placed ones: an unplaced piece still occupies
+  // an encoder position, so counting only placed ones lets a chunk overrun.
   while (tokenStart < pieces.length) {
     const tokenEnd = Math.min(pieces.length, tokenStart + maxTokens);
-    // Close each chunk at the *next* chunk's first token rather than at its own
-    // last one, so consecutive chunks meet with no gap. Characters between
-    // tokens have no boundary of their own — whitespace, but also anything the
-    // aligner could not place (an <unk>, a dropped or zero-width character) —
-    // and closing on our own last token would leave them in no chunk at all,
-    // silently unscanned. Every character lands in at least one chunk; with
-    // overlapTokens > 0 the shared region is deliberately in two, and
-    // mergeOverlappingNerSpans dedupes the results.
+    // Close on the *next* chunk's first token: characters between tokens have no
+    // boundary of their own and would otherwise land in no chunk at all.
     const boundary = tokenEnd >= pieces.length ? pieces.length : chunkBoundaryIndex(ranges, tokenStart, tokenEnd);
     const startChar = tokenStart === 0 ? 0 : chunkStartChar(ranges, tokenStart);
     const endChar = boundary >= pieces.length ? text.length : ranges[boundary]!.start;
@@ -1090,15 +1045,7 @@ function expandSpanToTokenBoundaries(text: string, span: PiiSpan): PiiSpan {
   };
 }
 
-/**
- * Characters allowed to sit between two same-type fragments that still belong to
- * one entity.
- *
- * Sub-word pieces are usually flush. Multi-word names and addresses 
- * are separated by a single space ('FirstName LastName',
- * 'DE01 2345 6789'). Anything else (a comma, a bracket, a line break, a real
- * word) ends the entity.
- */
+/** A comma, bracket, line break or real word between two fragments ends the entity. */
 const JOINABLE_GAP_PATTERN = /^[ \t._@:/+-]*$/;
 const MAX_JOINABLE_GAP_CHARS = 3;
 
@@ -1110,13 +1057,6 @@ function isWordCharacter(char: string): boolean {
   return /^[\p{L}\p{N}_]$/u.test(char);
 }
 
-/**
- * Grow a range outward only when it stops inside a word.
- *
- * completing the word recovers the rest. The guard is that 
- * both the character inside the boundary and the one outside it 
- * must be word characters.
- */
 function completePartialWord(text: string, range: TokenCharRange): TokenCharRange {
   let { start, end } = range;
 
@@ -1144,40 +1084,22 @@ const EMAIL_DOMAIN_TAIL_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
   'MISC',
 ]);
 
-/**
- * Longest mislabelled stretch we will bridge inside a single identifier.
- */
 const MAX_INTRA_RUN_GAP_CHARS = 16;
 
-/**
- * Characters that can sit *inside* one identifier.
- *
- * Deliberately excludes every separator -- whitespace, comma, bracket, slash,
- * semicolon -- so a bridge can only ever close a gap within one value, never
- * reach across the boundary between two of them.
- */
+/** Excludes every separator, so a bridge cannot reach across two values. */
 const INTRA_RUN_BRIDGE_PATTERN = /^[\p{L}\p{N}_.\-+@]*$/u;
 
 function isBridgeableGap(bridge: string): boolean {
   return bridge.length <= MAX_INTRA_RUN_GAP_CHARS && INTRA_RUN_BRIDGE_PATTERN.test(bridge);
 }
 
-/** How far back a bridge may reach for the span it rejoins. */
 const INTRA_RUN_LOOKBACK_SPANS = 3;
 
 /**
  * Rejoin same-type spans that a mislabelled slice split apart mid-identifier.
  *
- * Grouping already bridges an unlabelled gap, but the model sometimes drops a
- * different label into the middle instead, and that middle span then falls under
- * its own threshold. Left split, the anonymizer redacts both ends and publishes
- * the middle in the clear: 't.tester@example.invalid' becomes a redacted 't.',
- * an exposed 'tester', and a redacted '@example.invalid'.
- *
- * The bridge must be identifier interior only. An earlier form asked merely for
- * no whitespace, which also joined 'a@b.example,c@d.example' and two people
- * written 'Mueller,Schmidt' into one span, giving one placeholder for two
- * distinct values.
+ * When that middle falls under its own threshold, both ends are redacted and
+ * 'tester' of 't.tester@example.invalid' is left in the clear.
  */
 function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
   const out: PiiSpan[] = [];
@@ -1189,9 +1111,7 @@ function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
       const candidate = out[i];
       if (candidate.entity_type !== span.entity_type || candidate.end > span.start) continue;
 
-      // An empty bridge counts: completing partial words can leave two halves of
-      // one identifier flush against each other with the mislabelled slice
-      // overlapping them both.
+      // An empty bridge counts: the two halves can end up flush.
       if (!isBridgeableGap(sliceTextByByteOffsets(text, candidate.end, span.start))) continue;
 
       candidate.end = span.end;
@@ -1205,7 +1125,6 @@ function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
       continue;
     }
 
-    // Anything the merge swallowed is no longer its own span.
     const absorber = out[mergedInto];
     out.splice(
       mergedInto + 1,
@@ -1246,16 +1165,13 @@ function stitchEmailDomains(text: string, spans: PiiSpan[]): PiiSpan[] {
 /**
  * Build spans from raw per-token predictions using real character offsets.
  *
- * 'ranges' must be the aligner's output for the same tokenizer call the model
- * saw, so 'item.index' addresses it directly. Grouping is by entity type plus
- * source adjacency rather than by the model's BIO prefixes. 'simple'
- * strategy therefore breaks one email into six groups.
+ * 'ranges' must be the aligner's output for the tokenizer call the model saw, so
+ * 'item.index' addresses it directly. Grouping is by entity type and source
+ * adjacency, not the model's BIO prefixes.
  *
- * A group's score is its opening token's score (HuggingFace's 'first' strategy).
- * Measured on real output, confidence concentrates on entity onset and decays
- * across continuation pieces: 'firstName.lastName@` scores
- * [0.999, 0.999, 0.473, 0.670, 0.586, 0.631], so averaging would push a genuine
- * address under the email gate.
+ * A group scores from its opening token ('first' strategy): confidence decays across
+ * continuation pieces -- 'firstName.lastName@' scores [0.999, 0.999, 0.473, 0.670,
+ * 0.586, 0.631] -- so averaging would drop a genuine address under the email gate.
  */
 export function alignedTokensToSpans(
   text: string,
@@ -1479,10 +1395,8 @@ export function createTransformersNerProvider(
       throwIfAborted(signal);
       const chunk = chunks[i];
 
-      // Offsets come from aligning the tokenizer's own pieces to the chunk.
-      // Transformers.js leaves 'start'/'end' undefined for token-classification,
-      // and reconstructing them by searching for each predicted fragment puts
-      // spans on the wrong words entirely (see token-offsets.ts).
+      // Transformers.js leaves 'start'/'end' undefined, and searching for each
+      // predicted fragment puts spans on the wrong words (see token-offsets.ts).
       const pieces = tokenizer ? safeTokenize(tokenizer, chunk.text) : null;
       const ranges = pieces ? alignTokensToText(chunk.text, pieces) : null;
       const coverage = ranges && pieces ? alignmentCoverage(ranges, pieces) : 0;

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -17,7 +17,18 @@ import type {
   PiiSpan,
 } from '../shared/message-types';
 import { loadSystemCheckResult } from '../shared/system-check-storage';
+import {
+  byteLength,
+  byteOffsetToStringIndex,
+  sliceTextByByteOffsets,
+  stringIndexToByteOffset,
+} from '../shared/text-offsets';
 import { debugLog } from './debug';
+import {
+  alignTokensToText,
+  alignmentCoverage,
+  type TokenCharRange,
+} from './token-offsets';
 
 export interface NerProvider {
   readonly mode: NerProviderMode;
@@ -54,12 +65,27 @@ export type TokenClassificationItem = {
   entity_group?: string;
   start?: number;
   end?: number;
+  /**
+   * Position of this token in the tokenizer's 'input_ids'. Present only for raw
+   * output. It is the join key back onto the offset table containing start and end.
+   */
+  index?: number;
 };
 
-type TokenClassificationPipeline = (
+/**
+ * The slice of 'PreTrainedTokenizer'
+ */
+export interface NerTokenizerLike {
+  tokenize(text: string, options?: { add_special_tokens?: boolean }): string[];
+  readonly model_max_length?: number;
+}
+
+type TokenClassificationPipeline = ((
   text: string,
-  options?: { aggregation_strategy?: 'simple'; ignore_labels?: string[] }
-) => Promise<TokenClassificationItem[]>;
+  options?: { aggregation_strategy?: 'simple' | 'none'; ignore_labels?: string[] }
+) => Promise<TokenClassificationItem[]>) & {
+  tokenizer?: NerTokenizerLike;
+};
 
 type OnnxWasmPaths = string | { mjs?: string; wasm?: string };
 
@@ -95,11 +121,15 @@ type TransformersModule = {
   ) => Promise<TokenClassificationPipeline>;
 };
 
-interface NavigatorWithWebGpu extends Navigator {
+/**
+ * A navigator-like object that may expose WebGPU (optional).
+ * See a full note in 'src/system-check/passive-signals.ts'.
+ */
+type NavigatorWithWebGpu = Partial<Navigator> & {
   gpu?: {
     requestAdapter?: () => Promise<unknown>;
   };
-}
+};
 
 interface TransformersProviderOptions {
   modelKey?: NerModelKey;
@@ -153,6 +183,17 @@ const REQUIRED_RUNTIME_ASSETS = [
 ] as const;
 
 export const DEFAULT_NER_CHUNK_OVERLAP_CHARS = 256;
+
+/**
+ * Token budget per chunk.
+ */
+export const DEFAULT_NER_MAX_TOKENS_PER_CHUNK = 480;
+export const DEFAULT_NER_CHUNK_OVERLAP_TOKENS = 64;
+
+/**
+ * Character ceiling used when no tokenizer is available to chunk by token.
+ */
+export const FALLBACK_MAX_CHUNK_CHARS = 800;
 
 // Distilbert-uncased + AI4Privacy emits softer scores than typical NER models
 // (e.g., a clear "Acme Corp" landed at 0.46 in real test traffic). Privacy
@@ -396,15 +437,10 @@ const FIXTURE_ENTITIES: readonly FixtureEntity[] = [
   { text: '1234567890', entityType: 'BANK_ACCOUNT', score: 0.86 },
 ];
 
-const encoder = new TextEncoder();
 // Keyed by model AND WebGPU dtype preference: a provider pins its pipeline
 // (and thus its ONNX artifact) on first detect, so switching the preference
 // must produce a fresh provider instead of reusing a stale pipeline.
 let cachedTransformersProviders = new Map<string, NerProvider>();
-
-function byteLength(text: string): number {
-  return encoder.encode(text).length;
-}
 
 function chunkBoundaryEnd(text: string, start: number, targetEnd: number, maxChunkChars: number): number {
   if (targetEnd >= text.length) return text.length;
@@ -453,6 +489,116 @@ export function chunkTextForNer(
 
     if (endChar >= text.length) break;
     startChar = Math.max(startChar + 1, endChar - boundedOverlap);
+  }
+
+  return chunks;
+}
+
+export interface NerTokenChunkingOptions {
+  maxTokens?: number;
+  overlapTokens?: number;
+}
+
+/**
+ * Below this share of placed tokens we stop trusting the offset table and fall
+ * back to the legacy search, which is less accurate but degrades visibly rather
+ * than silently pointing spans at the wrong words.
+ */
+export const MIN_ALIGNMENT_COVERAGE = 0.8;
+
+/** Positions reserved for the post-processor's `<s>` / `</s>` (or `[CLS]` / `[SEP]`). */
+const SPECIAL_TOKEN_BUDGET = 2;
+
+function safeTokenize(tokenizer: NerTokenizerLike, text: string): string[] | null {
+  try {
+    return tokenizer.tokenize(text, { add_special_tokens: true });
+  } catch (err) {
+    debugLog('[PG:ner] tokenize failed', err);
+    return null;
+  }
+}
+
+function tokenLimitFor(tokenizer: NerTokenizerLike): number {
+  const modelMax = tokenizer.model_max_length;
+  if (typeof modelMax !== 'number' || !Number.isFinite(modelMax) || modelMax <= SPECIAL_TOKEN_BUDGET) {
+    return DEFAULT_NER_MAX_TOKENS_PER_CHUNK;
+  }
+
+  return Math.min(DEFAULT_NER_MAX_TOKENS_PER_CHUNK, modelMax - SPECIAL_TOKEN_BUDGET);
+}
+
+/**
+ * Split text on token boundaries so no chunk can exceed the encoder's
+ * position limit.
+ *
+ * Boundaries are taken from the aligner's char ranges, so a chunk never cuts a
+ * word in half and no source character is dropped: alignTokensToText places
+ * every content token, and consecutive chunks are joined end-to-start.
+ */
+export function chunkTextByTokens(
+  text: string,
+  tokenizer: NerTokenizerLike,
+  options: NerTokenChunkingOptions = {}
+): NerTextChunk[] | null {
+  if (text.length === 0) return [];
+
+  const maxTokens = options.maxTokens ?? DEFAULT_NER_MAX_TOKENS_PER_CHUNK;
+  const overlapTokens = Math.min(options.overlapTokens ?? DEFAULT_NER_CHUNK_OVERLAP_TOKENS, maxTokens - 1);
+  if (maxTokens < 1) throw new Error('NER maxTokens must be at least 1.');
+  if (overlapTokens < 0) throw new Error('NER overlapTokens must be non-negative.');
+
+  let pieces: string[];
+  try {
+    pieces = tokenizer.tokenize(text, { add_special_tokens: false });
+  } catch {
+    return null;
+  }
+
+  const ranges = alignTokensToText(text, pieces);
+  const placed = ranges.filter((range): range is TokenCharRange => range !== null);
+  if (placed.length === 0) return null;
+
+  // sanity gate: if we could not place most of the tokens we do not trust
+  // the boundaries either, and the caller should fall back to character chunks.
+  if (alignmentCoverage(ranges) < 0.8) return null;
+  if (placed.length <= maxTokens) {
+    return [
+      {
+        text,
+        startChar: 0,
+        endChar: text.length,
+        startByte: 0,
+        endByte: byteLength(text),
+      },
+    ];
+  }
+
+  const chunks: NerTextChunk[] = [];
+  let tokenStart = 0;
+
+  while (tokenStart < placed.length) {
+    const tokenEnd = Math.min(placed.length, tokenStart + maxTokens);
+    // Close each chunk at the *next* chunk's first token rather than at its own
+    // last one, so consecutive chunks meet with no gap. Characters between
+    // tokens have no boundary of their own — whitespace, but also anything the
+    // aligner could not place (an <unk>, a dropped or zero-width character) —
+    // and closing on our own last token would leave them in no chunk at all,
+    // silently unscanned. Every character lands in at least one chunk; with
+    // overlapTokens > 0 the shared region is deliberately in two, and
+    // mergeOverlappingNerSpans dedupes the results.
+    const startChar = tokenStart === 0 ? 0 : placed[tokenStart].start;
+    const endChar = tokenEnd >= placed.length ? text.length : placed[tokenEnd].start;
+
+    chunks.push({
+      text: text.slice(startChar, endChar),
+      startChar,
+      endChar,
+      startByte: byteLength(text.slice(0, startChar)),
+      endByte: byteLength(text.slice(0, endChar)),
+    });
+
+    if (tokenEnd >= placed.length) break;
+    tokenStart = Math.max(tokenStart + 1, tokenEnd - overlapTokens);
   }
 
   return chunks;
@@ -845,33 +991,10 @@ function transformerItemToSpan(
   };
 }
 
-function charIndexForByteOffset(text: string, byteOffset: number): number {
-  if (byteOffset <= 0) return 0;
-
-  let bytes = 0;
-  for (let index = 0; index < text.length;) {
-    if (bytes >= byteOffset) return index;
-    const codePoint = text.codePointAt(index);
-    if (codePoint === undefined) return text.length;
-    const char = String.fromCodePoint(codePoint);
-    bytes += byteLength(char);
-    index += char.length;
-  }
-
-  return text.length;
-}
-
-function textSliceByByteRange(text: string, startByte: number, endByte: number): string {
-  return text.slice(
-    charIndexForByteOffset(text, startByte),
-    charIndexForByteOffset(text, endByte)
-  );
-}
-
 function canMergeAdjacentNerFragments(text: string, previous: PiiSpan, next: PiiSpan): boolean {
   if (previous.entity_type !== next.entity_type || previous.end > next.start) return false;
 
-  const gap = textSliceByByteRange(text, previous.end, next.start);
+  const gap = sliceTextByByteOffsets(text, previous.end, next.start);
   return gap.length <= 4 && /^[\s._@:/+\-(),]*$/.test(gap);
 }
 
@@ -887,7 +1010,7 @@ function mergeAdjacentNerFragments(text: string, spans: PiiSpan[]): PiiSpan[] {
 
     previous.end = span.end;
     previous.score = Math.max(previous.score, span.score);
-    previous.text = textSliceByByteRange(text, previous.start, previous.end);
+    previous.text = sliceTextByByteOffsets(text, previous.start, previous.end);
   }
 
   return merged;
@@ -898,8 +1021,10 @@ function isTokenCharacter(char: string): boolean {
 }
 
 function expandSpanToTokenBoundaries(text: string, span: PiiSpan): PiiSpan {
-  let startChar = charIndexForByteOffset(text, span.start);
-  let endChar = charIndexForByteOffset(text, span.end);
+  const originalStart = byteOffsetToStringIndex(text, span.start);
+  const originalEnd = byteOffsetToStringIndex(text, span.end);
+  let startChar = originalStart;
+  let endChar = originalEnd;
 
   while (startChar > 0 && isTokenCharacter(text.charAt(startChar - 1))) {
     startChar -= 1;
@@ -908,19 +1033,237 @@ function expandSpanToTokenBoundaries(text: string, span: PiiSpan): PiiSpan {
     endChar += 1;
   }
 
-  if (
-    startChar === charIndexForByteOffset(text, span.start) &&
-    endChar === charIndexForByteOffset(text, span.end)
-  ) {
+  if (startChar === originalStart && endChar === originalEnd) {
     return span;
   }
 
   return {
     ...span,
-    start: byteLength(text.slice(0, startChar)),
-    end: byteLength(text.slice(0, endChar)),
+    start: stringIndexToByteOffset(text, startChar),
+    end: stringIndexToByteOffset(text, endChar),
     text: text.slice(startChar, endChar),
   };
+}
+
+/**
+ * Characters allowed to sit between two same-type fragments that still belong to
+ * one entity.
+ *
+ * Sub-word pieces are usually flush. Multi-word names and addresses 
+ * are separated by a single space ('FirstName LastName',
+ * 'DE01 2345 6789'). Anything else (a comma, a bracket, a line break, a real
+ * word) ends the entity.
+ */
+const JOINABLE_GAP_PATTERN = /^[ \t._@:/+-]*$/;
+const MAX_JOINABLE_GAP_CHARS = 3;
+
+/**
+ * Longest unlabelled stretch we will bridge inside a single unbroken run of
+ * non-whitespace characters.
+ *
+ * The model sometimes mislabels a slice in the middle of an identifier. 
+ * If there is no whitespace anywhere in the gap, both detections
+ * belong to the same token run, and closing it can only over-redact
+ * characters that sit between two genuine hits.
+ */
+const MAX_INTRA_RUN_GAP_CHARS = 16;
+
+function isJoinableGap(gap: string): boolean {
+  if (gap.length <= MAX_JOINABLE_GAP_CHARS && JOINABLE_GAP_PATTERN.test(gap)) return true;
+  return gap.length <= MAX_INTRA_RUN_GAP_CHARS && !/\s/.test(gap);
+}
+
+function isWordCharacter(char: string): boolean {
+  return /^[\p{L}\p{N}_]$/u.test(char);
+}
+
+/**
+ * Grow a range outward only when it stops inside a word.
+ *
+ * completing the word recovers the rest. The guard is that 
+ * both the character inside the boundary and the one outside it 
+ * must be word characters.
+ */
+function completePartialWord(text: string, range: TokenCharRange): TokenCharRange {
+  let { start, end } = range;
+
+  while (start > 0 && isWordCharacter(text.charAt(start)) && isWordCharacter(text.charAt(start - 1))) {
+    start -= 1;
+  }
+  while (end < text.length && isWordCharacter(text.charAt(end - 1)) && isWordCharacter(text.charAt(end))) {
+    end += 1;
+  }
+
+  return { start, end };
+}
+
+interface AlignedTokenPrediction {
+  entityType: EntityType;
+  rawLabel: string;
+  score: number;
+  range: TokenCharRange;
+}
+
+const EMAIL_DOMAIN_TAIL_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
+  'ORGANIZATION',
+  'URL',
+  'LOCATION',
+  'MISC',
+]);
+
+/**
+ * Rejoin same-type spans that a mislabelled slice split apart mid-identifier.
+ *
+ * Grouping already bridges an unlabelled gap, but the model sometimes puts a
+ * different label in the middle instead and the middle span then fell under 
+ * its own threshold. Requiring the whole bridge to be free of
+ * whitespace keeps this to a single token run.
+ */
+function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
+  const out: PiiSpan[] = [];
+
+  for (const span of spans) {
+    let mergedInto = -1;
+
+    for (let i = out.length - 1; i >= 0 && i >= out.length - 3; i -= 1) {
+      const candidate = out[i];
+      if (candidate.entity_type !== span.entity_type || candidate.end > span.start) continue;
+
+      // An empty bridge counts: completing partial words can leave two halves of
+      // one identifier flush against each other with the mislabelled slice
+      // overlapping them both.
+      const bridge = sliceTextByByteOffsets(text, candidate.end, span.start);
+      if (bridge.length > MAX_INTRA_RUN_GAP_CHARS || /\s/.test(bridge)) continue;
+
+      candidate.end = span.end;
+      candidate.text = sliceTextByByteOffsets(text, candidate.start, candidate.end);
+      mergedInto = i;
+      break;
+    }
+
+    if (mergedInto === -1) {
+      out.push(span);
+      continue;
+    }
+
+    // Anything the merge swallowed is no longer its own span.
+    const absorber = out[mergedInto];
+    out.splice(
+      mergedInto + 1,
+      out.length - mergedInto - 1,
+      ...out.slice(mergedInto + 1).filter((other) => other.end > absorber.end)
+    );
+  }
+
+  return out;
+}
+
+function stitchEmailDomains(text: string, spans: PiiSpan[]): PiiSpan[] {
+  const stitched: PiiSpan[] = [];
+
+  for (const span of spans) {
+    const previous = stitched[stitched.length - 1];
+    if (
+      previous &&
+      previous.entity_type === 'EMAIL' &&
+      EMAIL_DOMAIN_TAIL_TYPES.has(span.entity_type) &&
+      previous.end <= span.start
+    ) {
+      const gap = sliceTextByByteOffsets(text, previous.end, span.start);
+      const joinsAddress = gap === '@' || (gap === '' && previous.text.endsWith('@'));
+      if (joinsAddress) {
+        previous.end = span.end;
+        previous.text = sliceTextByByteOffsets(text, previous.start, previous.end);
+        continue;
+      }
+    }
+
+    stitched.push(span);
+  }
+
+  return stitched;
+}
+
+/**
+ * Build spans from raw per-token predictions using real character offsets.
+ *
+ * 'ranges' must be the aligner's output for the same tokenizer call the model
+ * saw, so 'item.index' addresses it directly. Grouping is by entity type plus
+ * source adjacency rather than by the model's BIO prefixes. 'simple'
+ * strategy therefore breaks one email into six groups.
+ *
+ * A group's score is its opening token's score (HuggingFace's 'first' strategy).
+ * Measured on real output, confidence concentrates on entity onset and decays
+ * across continuation pieces: 'firstName.lastName@` scores
+ * [0.999, 0.999, 0.473, 0.670, 0.586, 0.631], so averaging would push a genuine
+ * address under the email gate.
+ */
+export function alignedTokensToSpans(
+  text: string,
+  output: readonly TokenClassificationItem[],
+  ranges: readonly (TokenCharRange | null)[],
+  modelKey: NerModelKey = DEFAULT_NER_MODEL
+): PiiSpan[] {
+  const predictions: AlignedTokenPrediction[] = [];
+
+  for (const item of output) {
+    if (typeof item.index !== 'number') continue;
+
+    const rawLabel = item.entity_group ?? item.entity;
+    const entityType = mapTransformerLabelToEntityType(rawLabel, modelKey);
+    if (!entityType || !rawLabel) continue;
+
+    const range = ranges[item.index];
+    if (!range || range.start >= range.end) continue;
+
+    predictions.push({ entityType, rawLabel, score: item.score, range });
+  }
+
+  predictions.sort((a, b) => a.range.start - b.range.start || a.range.end - b.range.end);
+
+  const grouped: PiiSpan[] = [];
+  let current: { prediction: AlignedTokenPrediction; end: number } | null = null;
+
+  const flush = (): void => {
+    if (!current) return;
+    const range = completePartialWord(text, {
+      start: current.prediction.range.start,
+      end: current.end,
+    });
+    grouped.push({
+      start: stringIndexToByteOffset(text, range.start),
+      end: stringIndexToByteOffset(text, range.end),
+      entity_type: current.prediction.entityType,
+      score: current.prediction.score,
+      text: text.slice(range.start, range.end),
+      source: 'ner',
+      nerRawLabel: current.prediction.rawLabel,
+    });
+    current = null;
+  };
+
+  for (const prediction of predictions) {
+    if (!current) {
+      current = { prediction, end: prediction.range.end };
+      continue;
+    }
+
+    const sameType = current.prediction.entityType === prediction.entityType;
+    const gap = prediction.range.start >= current.end
+      ? text.slice(current.end, prediction.range.start)
+      : '';
+
+    if (sameType && prediction.range.start >= current.prediction.range.start && isJoinableGap(gap)) {
+      current.end = Math.max(current.end, prediction.range.end);
+      continue;
+    }
+
+    flush();
+    current = { prediction, end: prediction.range.end };
+  }
+  flush();
+
+  return stitchEmailDomains(text, closeIntraRunGaps(text, grouped));
 }
 
 export function transformerOutputToSpans(
@@ -1040,49 +1383,85 @@ export function createTransformersNerProvider(
     return pipelinePromise;
   }
 
+  function planChunks(text: string, tokenizer: NerTokenizerLike | undefined): NerTextChunk[] {
+    if (tokenizer) {
+      const tokenChunks = chunkTextByTokens(text, tokenizer, {
+        maxTokens: tokenLimitFor(tokenizer),
+      });
+      if (tokenChunks) return tokenChunks;
+      debugLog('[PG:ner] detect: token chunking unavailable, falling back to characters');
+    }
+
+    // No tokenizer to measure with, so cap on characters pessimistically rather
+    // than letting a long paste run past the encoder's 512 positions unseen.
+    return chunkTextForNer(text, {
+      ...chunking,
+      maxChunkChars: Math.min(chunking?.maxChunkChars ?? MAX_TEXT_LENGTH, FALLBACK_MAX_CHUNK_CHARS),
+    });
+  }
+
   async function detectChunked(
     text: string,
     classifier: TokenClassificationPipeline,
     signal?: AbortSignal
   ): Promise<{ spans: PiiSpan[]; chunkCount: number }> {
     throwIfAborted(signal);
-    const chunks = chunkTextForNer(text, chunking);
+    const tokenizer = classifier.tokenizer;
+    const chunks = planChunks(text, tokenizer);
     debugLog('[PG:ner] detect: chunked text', {
       model: model.key,
       textLength: text.length,
       chunkCount: chunks.length,
+      chunkedBy: tokenizer ? 'tokens' : 'characters',
     });
     const spans: PiiSpan[] = [];
 
     for (let i = 0; i < chunks.length; i += 1) {
       throwIfAborted(signal);
       const chunk = chunks[i];
+
+      // Offsets come from aligning the tokenizer's own pieces to the chunk.
+      // Transformers.js leaves 'start'/'end' undefined for token-classification,
+      // and reconstructing them by searching for each predicted fragment puts
+      // spans on the wrong words entirely (see token-offsets.ts).
+      const pieces = tokenizer ? safeTokenize(tokenizer, chunk.text) : null;
+      const ranges = pieces ? alignTokensToText(chunk.text, pieces) : null;
+      const coverage = ranges ? alignmentCoverage(ranges) : 0;
+      const useOffsets = ranges !== null && coverage >= MIN_ALIGNMENT_COVERAGE;
+
       const chunkStartedAt = performance.now();
-      const output = await classifier(chunk.text, { aggregation_strategy: 'simple' });
+      const output = await classifier(
+        chunk.text,
+        useOffsets ? { aggregation_strategy: 'none' } : { aggregation_strategy: 'simple' }
+      );
       throwIfAborted(signal);
       const inferenceMs = Math.round(performance.now() - chunkStartedAt);
-      const sample = output.slice(0, 10).map((item) => ({
-        word: item.word,
-        entity: item.entity_group ?? item.entity,
-        score: Number(item.score?.toFixed(3)),
-        start: item.start,
-        end: item.end,
-      }));
-      // Unconditional diagnostic — see comment in detect() above.
-      console.log('[PG:ner] detect: chunk inference', {
+
+      const converted = (
+        useOffsets
+          ? alignedTokensToSpans(chunk.text, output, ranges, model.key)
+          : transformerOutputToSpans(chunk.text, output, model.key)
+      ).map((span) => shiftSpanToOriginalText(span, chunk));
+
+      debugLog('[PG:ner] detect: chunk inference', {
         chunkIndex: i,
         chunkChars: chunk.text.length,
+        tokenCount: pieces?.length,
+        offsetMode: useOffsets ? 'aligned' : 'legacy-search',
+        alignmentCoverage: Number(coverage.toFixed(3)),
         inferenceMs,
         rawItemCount: output.length,
-        sample: sample.map((item) => ({ ...item, word: item.word ? `[${item.word.length} chars]` : item.word })),
-      });
-      const converted = transformerOutputToSpans(chunk.text, output, model.key).map((span) =>
-        shiftSpanToOriginalText(span, chunk)
-      );
-      debugLog('[PG:ner] detect: chunk converted to spans', {
-        chunkIndex: i,
         convertedSpanCount: converted.length,
       });
+
+      if (!useOffsets) {
+        console.warn('[PG:ner] detect: offset alignment unavailable, span positions are approximate', {
+          chunkIndex: i,
+          hasTokenizer: Boolean(tokenizer),
+          alignmentCoverage: Number(coverage.toFixed(3)),
+        });
+      }
+
       spans.push(...converted);
     }
 

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -560,7 +560,7 @@ export function chunkTextByTokens(
 
   // sanity gate: if we could not place most of the tokens we do not trust
   // the boundaries either, and the caller should fall back to character chunks.
-  if (alignmentCoverage(ranges) < 0.8) return null;
+  if (alignmentCoverage(ranges, pieces) < MIN_ALIGNMENT_COVERAGE) return null;
   if (placed.length <= maxTokens) {
     return [
       {
@@ -1057,20 +1057,8 @@ function expandSpanToTokenBoundaries(text: string, span: PiiSpan): PiiSpan {
 const JOINABLE_GAP_PATTERN = /^[ \t._@:/+-]*$/;
 const MAX_JOINABLE_GAP_CHARS = 3;
 
-/**
- * Longest unlabelled stretch we will bridge inside a single unbroken run of
- * non-whitespace characters.
- *
- * The model sometimes mislabels a slice in the middle of an identifier. 
- * If there is no whitespace anywhere in the gap, both detections
- * belong to the same token run, and closing it can only over-redact
- * characters that sit between two genuine hits.
- */
-const MAX_INTRA_RUN_GAP_CHARS = 16;
-
 function isJoinableGap(gap: string): boolean {
-  if (gap.length <= MAX_JOINABLE_GAP_CHARS && JOINABLE_GAP_PATTERN.test(gap)) return true;
-  return gap.length <= MAX_INTRA_RUN_GAP_CHARS && !/\s/.test(gap);
+  return gap.length <= MAX_JOINABLE_GAP_CHARS && JOINABLE_GAP_PATTERN.test(gap);
 }
 
 function isWordCharacter(char: string): boolean {
@@ -1110,53 +1098,6 @@ const EMAIL_DOMAIN_TAIL_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
   'LOCATION',
   'MISC',
 ]);
-
-/**
- * Rejoin same-type spans that a mislabelled slice split apart mid-identifier.
- *
- * Grouping already bridges an unlabelled gap, but the model sometimes puts a
- * different label in the middle instead and the middle span then fell under 
- * its own threshold. Requiring the whole bridge to be free of
- * whitespace keeps this to a single token run.
- */
-function closeIntraRunGaps(text: string, spans: PiiSpan[]): PiiSpan[] {
-  const out: PiiSpan[] = [];
-
-  for (const span of spans) {
-    let mergedInto = -1;
-
-    for (let i = out.length - 1; i >= 0 && i >= out.length - 3; i -= 1) {
-      const candidate = out[i];
-      if (candidate.entity_type !== span.entity_type || candidate.end > span.start) continue;
-
-      // An empty bridge counts: completing partial words can leave two halves of
-      // one identifier flush against each other with the mislabelled slice
-      // overlapping them both.
-      const bridge = sliceTextByByteOffsets(text, candidate.end, span.start);
-      if (bridge.length > MAX_INTRA_RUN_GAP_CHARS || /\s/.test(bridge)) continue;
-
-      candidate.end = span.end;
-      candidate.text = sliceTextByByteOffsets(text, candidate.start, candidate.end);
-      mergedInto = i;
-      break;
-    }
-
-    if (mergedInto === -1) {
-      out.push(span);
-      continue;
-    }
-
-    // Anything the merge swallowed is no longer its own span.
-    const absorber = out[mergedInto];
-    out.splice(
-      mergedInto + 1,
-      out.length - mergedInto - 1,
-      ...out.slice(mergedInto + 1).filter((other) => other.end > absorber.end)
-    );
-  }
-
-  return out;
-}
 
 function stitchEmailDomains(text: string, spans: PiiSpan[]): PiiSpan[] {
   const stitched: PiiSpan[] = [];
@@ -1263,7 +1204,7 @@ export function alignedTokensToSpans(
   }
   flush();
 
-  return stitchEmailDomains(text, closeIntraRunGaps(text, grouped));
+  return stitchEmailDomains(text, grouped);
 }
 
 export function transformerOutputToSpans(
@@ -1426,7 +1367,7 @@ export function createTransformersNerProvider(
       // spans on the wrong words entirely (see token-offsets.ts).
       const pieces = tokenizer ? safeTokenize(tokenizer, chunk.text) : null;
       const ranges = pieces ? alignTokensToText(chunk.text, pieces) : null;
-      const coverage = ranges ? alignmentCoverage(ranges) : 0;
+      const coverage = ranges && pieces ? alignmentCoverage(ranges, pieces) : 0;
       const useOffsets = ranges !== null && coverage >= MIN_ALIGNMENT_COVERAGE;
 
       const chunkStartedAt = performance.now();

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -1156,8 +1156,16 @@ function closeIntraRunGaps(text: string, spans: PiiSpan[], modelKey: NerModelKey
       // An empty bridge counts: the two halves can end up flush.
       if (!isBridgeableGap(sliceTextByByteOffsets(text, candidate.end, span.start))) continue;
 
-      // Same-type evidence may support the whole repair, but a failing repair
-      // must never delete a passing differently labelled middle.
+      // A confident conflicting label is independent evidence, not a gap to
+      // repair. Keep it separate instead of replacing its identity with ours.
+      const hasPassingMiddle = out.slice(i + 1).some((other) =>
+        other.entity_type !== candidate.entity_type &&
+        other.start < span.end && other.end > candidate.start &&
+        passesNerThreshold(other, modelKey)
+      );
+      if (hasPassingMiddle) continue;
+
+      // Same-type evidence may support a repair over unlabelled or weak pieces.
       const score = Math.max(candidate.score, span.score);
       if (!passesNerThreshold({ ...candidate, score }, modelKey)) continue;
       candidate.score = score;

--- a/src/offscreen/ner-provider.ts
+++ b/src/offscreen/ner-provider.ts
@@ -123,7 +123,10 @@ type TransformersModule = {
 
 /**
  * A navigator-like object that may expose WebGPU (optional).
- * See a full note in 'src/system-check/passive-signals.ts'.
+ *
+ * 'Partial<Navigator>' rather than an extension of it: the offscreen document's
+ * navigator is typed from whichever DOM lib is in scope, and only the members
+ * read here matter.
  */
 type NavigatorWithWebGpu = Partial<Navigator> & {
   gpu?: {

--- a/src/offscreen/token-offsets.ts
+++ b/src/offscreen/token-offsets.ts
@@ -1,33 +1,20 @@
 /**
  * Character-offset recovery for token-classification output.
  *
- * Transformers.js does not emit 'start' / 'end' for the token-classification
- * pipeline. Every item comes back with 'start: undefined, end: undefined', 
- * so the only way to place a prediction back into the source text is to 
- * align the tokenizer's own pieces against it.
- *
- * Here we align the complete piece sequence instead. With no gaps in the sequence the cursor 
- * cannot skip ahead, so each piece lands on its true source characters.
- *
- * Supported tokenizer styles:
- *  - SentencePiece / Metaspace (XLM-R, the BardsAI model): word-initial pieces
- *    carry a `▁` prefix, continuations carry nothing.
- *  - WordPiece (DistilBERT, the AI4Privacy and HikmaAI models): continuation
- *    pieces carry a `##` prefix, word-initial pieces carry nothing. These are
- *    `-uncased` checkpoints that also strip accents, so matching folds case and
- *    combining marks.
+ * Transformers.js leaves 'start' / 'end' undefined, so predictions are placed by
+ * aligning the tokenizer's own pieces against the source. Handles Metaspace ('▁'
+ * on word-initial pieces) and WordPiece ('##' on continuations); the WordPiece
+ * checkpoints are '-uncased', so matching folds case and accents.
  */
 
 const METASPACE = '▁';
 const WORDPIECE_CONTINUATION = '##';
 
-/** CHAR gap after the cursor when a piece does not match the verbatim. */
+/** How far to scan forward when a piece does not match at the cursor. */
 const RESYNC_WINDOW_CHARS = 48;
 
 export interface TokenCharRange {
-  /** Inclusive character index into the original (un-normalized) text. */
   start: number;
-  /** Exclusive character index into the original text. */
   end: number;
 }
 
@@ -44,13 +31,7 @@ const DEFAULT_SPECIAL_TOKENS: readonly string[] = [
   '[MASK]',
 ];
 
-/**
- * Case and accent-folded view of a string, with an index back to the original.
- *
- * 'folded[i]' corresponds to 'sourceIndex[i]' in the original text. Folding is
- * applied per source character, so one source character may contribute zero or several 
- * folded characters. The index array keeps the mapping exact either way.
- */
+/** One source character may fold to zero or several, so 'sourceIndex' maps back. */
 interface FoldedText {
   folded: string;
   sourceIndex: number[];
@@ -79,7 +60,6 @@ function foldText(text: string): FoldedText {
     index += char.length;
   }
 
-  // a match that runs to the very end can resolve its exclusive end.
   sourceIndex.push(text.length);
   return { folded, sourceIndex };
 }
@@ -103,18 +83,13 @@ function detectStyle(tokens: readonly string[]): TokenizerStyle {
 }
 
 interface PieceShape {
-  /** Literal segments to match, in order, separated by word boundaries. */
   segments: string[];
-  /** Whether a whitespace run may be consumed before the first segment. */
   boundaryBefore: boolean;
 }
 
 /**
- * Split a raw token into the literal text it stands for.
- *
- * Metaspace pieces may contain '▁' internally: this tokenizer's normalizer
- * rewrites runs of two or more spaces to a literal '▁' before pre-tokenization,
- * so '▁a▁b' means "word boundary, 'a', whitespace run, 'b'".
+ * Metaspace pieces can contain '▁' internally: the normalizer rewrites runs of two
+ * or more spaces to a literal '▁', so '▁a▁b' is "boundary, a, spaces, b".
  */
 function pieceShape(token: string, style: TokenizerStyle): PieceShape {
   if (style === 'wordpiece') {
@@ -134,13 +109,7 @@ function skipWhitespace(text: string, from: number): number {
   return index;
 }
 
-/**
- * Try to match 'segments' starting at source index 'from'.
- *
- * Returns the exclusive end index, or 'null' when the segments do not line up.
- * Matching happens in folded space so that '-uncased', accent-stripping
- * tokenizers still align against the original cased text.
- */
+/** Matches in folded space so '-uncased' tokenizers align against cased text. */
 function matchSegments(
   text: string,
   foldedText: FoldedText,
@@ -173,14 +142,9 @@ function matchSegments(
 }
 
 /**
- * Map every token in 'tokens' to its character range in 'text'.
- *
- * 'tokens' must be the tokenizer's complete output for 'text' (the same call
- * the model saw, special tokens included) so that indices line up with the
- * 'index' field on token-classification items.
- *
- * Returns one entry per token: a range, or 'null' for special tokens, empty
- * pieces, and any piece that could not be placed.
+ * 'tokens' must be the tokenizer's complete output for 'text' -- the same call the
+ * model saw, specials included -- so indices line up with an item's 'index'.
+ * Entries are 'null' for specials, empty pieces, and anything unplaceable.
  */
 export function alignTokensToText(
   text: string,
@@ -190,7 +154,6 @@ export function alignTokensToText(
   const style = detectStyle(tokens);
   const foldedText = foldText(text);
 
-  // Reverse of foldedText.sourceIndex: first folded position for a source index.
   const foldedStartBySource: number[] = new Array(text.length + 1).fill(-1);
   for (let foldedIndex = foldedText.sourceIndex.length - 1; foldedIndex >= 0; foldedIndex -= 1) {
     foldedStartBySource[foldedText.sourceIndex[foldedIndex]] = foldedIndex;
@@ -213,8 +176,7 @@ export function alignTokensToText(
 
     const { segments, boundaryBefore } = pieceShape(token, style);
     if (segments.length === 0) {
-      // Metaspace-only piece: it stands for whitespace, not content. Consume the
-      // whitespace so the next piece starts in the right place, but emit no range.
+      // Whitespace, not content: consume it but emit no range.
       if (boundaryBefore) cursor = skipWhitespace(text, cursor);
       ranges.push(null);
       continue;
@@ -229,9 +191,8 @@ export function alignTokensToText(
       boundaryBefore
     );
 
-    // Resync: an <unk> or a normalization we do not model consumed source
-    // characters we did not account for. Scan forward a bounded window rather
-    // than giving up on the rest of the sequence.
+    // An <unk> or unmodelled normalization ate characters; scan a bounded window
+    // rather than abandoning the rest of the sequence.
     if (!matched) {
       const limit = Math.min(text.length, cursor + RESYNC_WINDOW_CHARS);
       for (let probe = cursor + 1; probe <= limit; probe += 1) {
@@ -259,13 +220,7 @@ export function alignTokensToText(
   return ranges;
 }
 
-/**
- * Fraction of content-bearing tokens that were placed successfully.
- *
- * The provider uses this as a health check: if alignment degrades on some text
- * we have not anticipated, it is better to fall back than to emit spans at
- * confidently wrong positions.
- */
+/** Fraction of content-bearing tokens placed; the provider's gate for falling back. */
 export function alignmentCoverage(
   ranges: readonly (TokenCharRange | null)[],
   tokens: readonly string[]
@@ -275,8 +230,7 @@ export function alignmentCoverage(
   let content = 0;
   let placed = 0;
   ranges.forEach((range, index) => {
-    // A special token is aligned to null by design, so counting it as a failure
-    // would push short text under the gate and back onto the legacy search.
+    // Null by design; counting it as a failure would push short text under the gate.
     if (specialTokens.has(tokens[index])) return;
     content += 1;
     if (range) placed += 1;

--- a/src/offscreen/token-offsets.ts
+++ b/src/offscreen/token-offsets.ts
@@ -1,0 +1,282 @@
+/**
+ * Character-offset recovery for token-classification output.
+ *
+ * Transformers.js does not emit 'start' / 'end' for the token-classification
+ * pipeline. Every item comes back with 'start: undefined, end: undefined', 
+ * so the only way to place a prediction back into the source text is to 
+ * align the tokenizer's own pieces against it.
+ *
+ * Here we align the complete piece sequence instead. With no gaps in the sequence the cursor 
+ * cannot skip ahead, so each piece lands on its true source characters.
+ *
+ * Supported tokenizer styles:
+ *  - SentencePiece / Metaspace (XLM-R, the BardsAI model): word-initial pieces
+ *    carry a `▁` prefix, continuations carry nothing.
+ *  - WordPiece (DistilBERT, the AI4Privacy and HikmaAI models): continuation
+ *    pieces carry a `##` prefix, word-initial pieces carry nothing. These are
+ *    `-uncased` checkpoints that also strip accents, so matching folds case and
+ *    combining marks.
+ */
+
+const METASPACE = '▁';
+const WORDPIECE_CONTINUATION = '##';
+
+/** CHAR gap after the cursor when a piece does not match the verbatim. */
+const RESYNC_WINDOW_CHARS = 48;
+
+export interface TokenCharRange {
+  /** Inclusive character index into the original (un-normalized) text. */
+  start: number;
+  /** Exclusive character index into the original text. */
+  end: number;
+}
+
+export interface AlignTokensOptions {
+  /**
+   * Tokens that stand for no source characters ('<s>', '</s>', '[CLS]', …).
+   * Matched exactly; anything listed here is aligned to `null`.
+   */
+  specialTokens?: readonly string[];
+}
+
+const DEFAULT_SPECIAL_TOKENS: readonly string[] = [
+  '<s>',
+  '</s>',
+  '<pad>',
+  '<unk>',
+  '<mask>',
+  '[CLS]',
+  '[SEP]',
+  '[PAD]',
+  '[UNK]',
+  '[MASK]',
+];
+
+/**
+ * Case and accent-folded view of a string, with an index back to the original.
+ *
+ * 'folded[i]' corresponds to 'sourceIndex[i]' in the original text. Folding is
+ * applied per source character, so one source character may contribute zero or several 
+ * folded characters. The index array keeps the mapping exact either way.
+ */
+interface FoldedText {
+  folded: string;
+  sourceIndex: number[];
+}
+
+function foldChar(char: string): string {
+  return char
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{M}+/gu, '');
+}
+
+function foldText(text: string): FoldedText {
+  let folded = '';
+  const sourceIndex: number[] = [];
+
+  for (let index = 0; index < text.length; ) {
+    const codePoint = text.codePointAt(index)!;
+    const char = String.fromCodePoint(codePoint);
+    const replacement = foldChar(char);
+
+    for (let k = 0; k < replacement.length; k += 1) {
+      sourceIndex.push(index);
+    }
+    folded += replacement;
+    index += char.length;
+  }
+
+  // a match that runs to the very end can resolve its exclusive end.
+  sourceIndex.push(text.length);
+  return { folded, sourceIndex };
+}
+
+function foldPiece(piece: string): string {
+  let out = '';
+  for (const char of piece) {
+    out += foldChar(char);
+  }
+  return out;
+}
+
+type TokenizerStyle = 'metaspace' | 'wordpiece';
+
+function detectStyle(tokens: readonly string[]): TokenizerStyle {
+  for (const token of tokens) {
+    if (token.startsWith(METASPACE)) return 'metaspace';
+    if (token.startsWith(WORDPIECE_CONTINUATION)) return 'wordpiece';
+  }
+  return 'metaspace';
+}
+
+interface PieceShape {
+  /** Literal segments to match, in order, separated by word boundaries. */
+  segments: string[];
+  /** Whether a whitespace run may be consumed before the first segment. */
+  boundaryBefore: boolean;
+}
+
+/**
+ * Split a raw token into the literal text it stands for.
+ *
+ * Metaspace pieces may contain '▁' internally: this tokenizer's normalizer
+ * rewrites runs of two or more spaces to a literal '▁' before pre-tokenization,
+ * so '▁a▁b' means "word boundary, 'a', whitespace run, 'b'".
+ */
+function pieceShape(token: string, style: TokenizerStyle): PieceShape {
+  if (style === 'wordpiece') {
+    return token.startsWith(WORDPIECE_CONTINUATION)
+      ? { segments: [token.slice(WORDPIECE_CONTINUATION.length)], boundaryBefore: false }
+      : { segments: [token], boundaryBefore: true };
+  }
+
+  const boundaryBefore = token.startsWith(METASPACE);
+  const segments = token.split(METASPACE).filter((segment) => segment.length > 0);
+  return { segments, boundaryBefore };
+}
+
+function skipWhitespace(text: string, from: number): number {
+  let index = from;
+  while (index < text.length && /\s/.test(text.charAt(index))) index += 1;
+  return index;
+}
+
+/**
+ * Try to match 'segments' starting at source index 'from'.
+ *
+ * Returns the exclusive end index, or 'null' when the segments do not line up.
+ * Matching happens in folded space so that '-uncased', accent-stripping
+ * tokenizers still align against the original cased text.
+ */
+function matchSegments(
+  text: string,
+  foldedText: FoldedText,
+  foldedStartBySource: number[],
+  segments: readonly string[],
+  from: number,
+  allowLeadingWhitespace: boolean
+): { start: number; end: number } | null {
+  let sourceCursor = allowLeadingWhitespace ? skipWhitespace(text, from) : from;
+  const start = sourceCursor;
+
+  for (let i = 0; i < segments.length; i += 1) {
+    if (i > 0) sourceCursor = skipWhitespace(text, sourceCursor);
+
+    const needle = foldPiece(segments[i]);
+    if (needle.length === 0) continue;
+
+    const foldedCursor = foldedStartBySource[sourceCursor];
+    if (foldedCursor === undefined) return null;
+    if (!foldedText.folded.startsWith(needle, foldedCursor)) return null;
+
+    const foldedEnd = foldedCursor + needle.length;
+    const nextSource = foldedText.sourceIndex[foldedEnd];
+    if (nextSource === undefined) return null;
+    sourceCursor = nextSource;
+  }
+
+  if (sourceCursor <= start && segments.some((segment) => segment.length > 0)) return null;
+  return { start, end: sourceCursor };
+}
+
+/**
+ * Map every token in 'tokens' to its character range in 'text'.
+ *
+ * 'tokens' must be the tokenizer's complete output for 'text' (the same call
+ * the model saw, special tokens included) so that indices line up with the
+ * 'index' field on token-classification items.
+ *
+ * Returns one entry per token: a range, or 'null' for special tokens, empty
+ * pieces, and any piece that could not be placed.
+ */
+export function alignTokensToText(
+  text: string,
+  tokens: readonly string[],
+  options: AlignTokensOptions = {}
+): (TokenCharRange | null)[] {
+  const specialTokens = new Set(options.specialTokens ?? DEFAULT_SPECIAL_TOKENS);
+  const style = detectStyle(tokens);
+  const foldedText = foldText(text);
+
+  // Reverse of foldedText.sourceIndex: first folded position for a source index.
+  const foldedStartBySource: number[] = new Array(text.length + 1).fill(-1);
+  for (let foldedIndex = foldedText.sourceIndex.length - 1; foldedIndex >= 0; foldedIndex -= 1) {
+    foldedStartBySource[foldedText.sourceIndex[foldedIndex]] = foldedIndex;
+  }
+  // Source characters that fold away entirely inherit the next real position.
+  let carry = foldedText.folded.length;
+  for (let sourceIndex = text.length; sourceIndex >= 0; sourceIndex -= 1) {
+    if (foldedStartBySource[sourceIndex] === -1) foldedStartBySource[sourceIndex] = carry;
+    else carry = foldedStartBySource[sourceIndex];
+  }
+
+  const ranges: (TokenCharRange | null)[] = [];
+  let cursor = 0;
+
+  for (const token of tokens) {
+    if (specialTokens.has(token)) {
+      ranges.push(null);
+      continue;
+    }
+
+    const { segments, boundaryBefore } = pieceShape(token, style);
+    if (segments.length === 0) {
+      // Metaspace-only piece: it stands for whitespace, not content. Consume the
+      // whitespace so the next piece starts in the right place, but emit no range.
+      if (boundaryBefore) cursor = skipWhitespace(text, cursor);
+      ranges.push(null);
+      continue;
+    }
+
+    let matched = matchSegments(
+      text,
+      foldedText,
+      foldedStartBySource,
+      segments,
+      cursor,
+      boundaryBefore
+    );
+
+    // Resync: an <unk> or a normalization we do not model consumed source
+    // characters we did not account for. Scan forward a bounded window rather
+    // than giving up on the rest of the sequence.
+    if (!matched) {
+      const limit = Math.min(text.length, cursor + RESYNC_WINDOW_CHARS);
+      for (let probe = cursor + 1; probe <= limit; probe += 1) {
+        matched = matchSegments(
+          text,
+          foldedText,
+          foldedStartBySource,
+          segments,
+          probe,
+          boundaryBefore
+        );
+        if (matched) break;
+      }
+    }
+
+    if (!matched) {
+      ranges.push(null);
+      continue;
+    }
+
+    ranges.push({ start: matched.start, end: matched.end });
+    cursor = matched.end;
+  }
+
+  return ranges;
+}
+
+/**
+ * Fraction of content-bearing tokens that were placed successfully.
+ *
+ * The provider uses this as a health check: if alignment degrades on some text
+ * we have not anticipated, it is better to fall back than to emit spans at
+ * confidently wrong positions.
+ */
+export function alignmentCoverage(ranges: readonly (TokenCharRange | null)[]): number {
+  if (ranges.length === 0) return 1;
+  const placed = ranges.reduce<number>((count, range) => count + (range ? 1 : 0), 0);
+  return placed / ranges.length;
+}

--- a/src/offscreen/token-offsets.ts
+++ b/src/offscreen/token-offsets.ts
@@ -31,14 +31,6 @@ export interface TokenCharRange {
   end: number;
 }
 
-export interface AlignTokensOptions {
-  /**
-   * Tokens that stand for no source characters ('<s>', '</s>', '[CLS]', …).
-   * Matched exactly; anything listed here is aligned to `null`.
-   */
-  specialTokens?: readonly string[];
-}
-
 const DEFAULT_SPECIAL_TOKENS: readonly string[] = [
   '<s>',
   '</s>',
@@ -192,10 +184,9 @@ function matchSegments(
  */
 export function alignTokensToText(
   text: string,
-  tokens: readonly string[],
-  options: AlignTokensOptions = {}
+  tokens: readonly string[]
 ): (TokenCharRange | null)[] {
-  const specialTokens = new Set(options.specialTokens ?? DEFAULT_SPECIAL_TOKENS);
+  const specialTokens = new Set(DEFAULT_SPECIAL_TOKENS);
   const style = detectStyle(tokens);
   const foldedText = foldText(text);
 
@@ -275,8 +266,22 @@ export function alignTokensToText(
  * we have not anticipated, it is better to fall back than to emit spans at
  * confidently wrong positions.
  */
-export function alignmentCoverage(ranges: readonly (TokenCharRange | null)[]): number {
-  if (ranges.length === 0) return 1;
-  const placed = ranges.reduce<number>((count, range) => count + (range ? 1 : 0), 0);
-  return placed / ranges.length;
+export function alignmentCoverage(
+  ranges: readonly (TokenCharRange | null)[],
+  tokens: readonly string[]
+): number {
+  const specialTokens = new Set(DEFAULT_SPECIAL_TOKENS);
+
+  let content = 0;
+  let placed = 0;
+  ranges.forEach((range, index) => {
+    // A special token is aligned to null by design, so counting it as a failure
+    // would push short text under the gate and back onto the legacy search.
+    if (specialTokens.has(tokens[index])) return;
+    content += 1;
+    if (range) placed += 1;
+  });
+
+  if (content === 0) return 1;
+  return placed / content;
 }

--- a/src/offscreen/token-offsets.ts
+++ b/src/offscreen/token-offsets.ts
@@ -145,10 +145,13 @@ function matchSegments(
  * 'tokens' must be the tokenizer's complete output for 'text' -- the same call the
  * model saw, specials included -- so indices line up with an item's 'index'.
  * Entries are 'null' for specials, empty pieces, and anything unplaceable.
+ * Set addSpecialTokens:false when aligning pieces without the post-processor's
+ * boundary tokens, so a literal '<s>' at the start is still consumed.
  */
 export function alignTokensToText(
   text: string,
-  tokens: readonly string[]
+  tokens: readonly string[],
+  options: { addSpecialTokens?: boolean } = {}
 ): (TokenCharRange | null)[] {
   const specialTokens = new Set(DEFAULT_SPECIAL_TOKENS);
   const style = detectStyle(tokens);
@@ -168,8 +171,18 @@ export function alignTokensToText(
   const ranges: (TokenCharRange | null)[] = [];
   let cursor = 0;
 
-  for (const token of tokens) {
+  for (const [index, token] of tokens.entries()) {
     if (specialTokens.has(token)) {
+      const insertedBoundary = options.addSpecialTokens !== false && (
+        (index === 0 && (token === '<s>' || token === '[CLS]')) ||
+        (index === tokens.length - 1 && (token === '</s>' || token === '[SEP]'))
+      );
+      // A literal control token occupies source text even though the classifier
+      // emits no prediction for it. Do not resync into its spelling later.
+      const literalStart = skipWhitespace(text, cursor);
+      if (!insertedBoundary && text.startsWith(token, literalStart)) {
+        cursor = literalStart + token.length;
+      }
       ranges.push(null);
       continue;
     }
@@ -231,7 +244,7 @@ export function alignmentCoverage(
   let placed = 0;
   ranges.forEach((range, index) => {
     // Null by design; counting it as a failure would push short text under the gate.
-    if (specialTokens.has(tokens[index])) return;
+    if (specialTokens.has(tokens[index]) || /^▁+$/.test(tokens[index])) return;
     content += 1;
     if (range) placed += 1;
   });

--- a/src/system-check/passive-signals.ts
+++ b/src/system-check/passive-signals.ts
@@ -1,30 +1,11 @@
 import type { PassiveSystemSignals, WebGpuAvailability } from '../shared/system-compatibility-policy';
 
-/**
- * A navigator-like object carrying the optional hardware signals for probing.
- * 
- *    In TypeScript, Partial<T> constructs a type with all properties of T 
- *    set to optional. Useful for testing, mocking, or building safe 
- *    feature-detection utilities.
- *
- *    Put `Partial<Navigator> &` instead of `extends Navigator` because:
- * 
- *  - GPU is required in the newer lib.dom.d.ts which fails on extending 
- *    optional 'gpu?'. So an editor with its own typescript bundle might
- *    report it but workspace 'tsc' might not.
- * 
- *  - Not extending the 'Navigator' will remove properties common with 'Navigator'
- *    so callers passing '{...} as Navigator' will fail.
- *    
- *  - Hence using 'Partial<Navigator>' will keep the overlap that casting needs
- *    and type-checks under both old and new DOM lib version
- */
-type NavigatorWithPassiveHardwareSignals = Partial<Navigator> & {
+interface NavigatorWithPassiveHardwareSignals extends Navigator {
   deviceMemory?: number;
   gpu?: {
     requestAdapter?: () => Promise<unknown>;
   };
-};
+}
 
 async function collectPassiveWebGpuAvailability(navigatorLike: NavigatorWithPassiveHardwareSignals): Promise<WebGpuAvailability> {
   if (!navigatorLike.gpu) return 'unavailable';

--- a/src/system-check/passive-signals.ts
+++ b/src/system-check/passive-signals.ts
@@ -1,11 +1,30 @@
 import type { PassiveSystemSignals, WebGpuAvailability } from '../shared/system-compatibility-policy';
 
-interface NavigatorWithPassiveHardwareSignals extends Navigator {
+/**
+ * A navigator-like object carrying the optional hardware signals for probing.
+ * 
+ *    In TypeScript, Partial<T> constructs a type with all properties of T 
+ *    set to optional. Useful for testing, mocking, or building safe 
+ *    feature-detection utilities.
+ *
+ *    Put `Partial<Navigator> &` instead of `extends Navigator` because:
+ * 
+ *  - GPU is required in the newer lib.dom.d.ts which fails on extending 
+ *    optional 'gpu?'. So an editor with its own typescript bundle might
+ *    report it but workspace 'tsc' might not.
+ * 
+ *  - Not extending the 'Navigator' will remove properties common with 'Navigator'
+ *    so callers passing '{...} as Navigator' will fail.
+ *    
+ *  - Hence using 'Partial<Navigator>' will keep the overlap that casting needs
+ *    and type-checks under both old and new DOM lib version
+ */
+type NavigatorWithPassiveHardwareSignals = Partial<Navigator> & {
   deviceMemory?: number;
   gpu?: {
     requestAdapter?: () => Promise<unknown>;
   };
-}
+};
 
 async function collectPassiveWebGpuAvailability(navigatorLike: NavigatorWithPassiveHardwareSignals): Promise<WebGpuAvailability> {
   if (!navigatorLike.gpu) return 'unavailable';

--- a/tests/offscreen/ner-aligned-spans.test.ts
+++ b/tests/offscreen/ner-aligned-spans.test.ts
@@ -1,0 +1,373 @@
+import {
+  alignedTokensToSpans,
+  applyNerThresholdPolicy,
+  chunkTextByTokens,
+  createTransformersNerProvider,
+  resetNerProviderCachesForTests,
+  type NerTokenizerLike,
+  type TokenClassificationItem,
+} from '../../src/offscreen/ner-provider';
+import { alignTokensToText } from '../../src/offscreen/token-offsets';
+import { sliceTextByByteOffsets } from '../../src/shared/text-offsets';
+
+/**
+ * The token list, indices, labels and scores below are the genuine output of
+ * the BardsAI q4f16 model on this exact text, captured so the test pins real
+ * behaviour rather than an idealised guess. Two properties matter:
+ */
+const THREAD_TEXT =
+  'Von: Max Muster max.muster@example.invalid\n' +
+  'Cc: Erika Beispiel <erika.beispiel@example.invalid>, Klaus Muster <klaus.muster@example.invalid>\n' +
+  'Letzte Rückmeldung bis Freitag! Der Termin fällt leider aus und kommt frühestens im Oktober wieder.\n' +
+  'Schreibt lieber an t.tester@example.invalid.';
+
+const THREAD_PIECES = ['<s>','▁Von',':','▁Max','▁Must','er','▁max','.','mu','ster','@','ex','a','mple','.','in','vali','d','▁C','c',':','▁Erik','a','▁Beispiel','▁<','e','rika','.','bei','spiel','@','ex','a','mple','.','in','vali','d','>',',','▁Klaus','▁Must','er','▁<','klaus','.','mu','ster','@','ex','a','mple','.','in','vali','d','>','▁Letzte','▁Rück','meldung','▁bis','▁Freitag','!','▁Der','▁Termin','▁fällt','▁leider','▁aus','▁und','▁kommt','▁früh','esten','s','▁im','▁Oktober','▁wieder','.','▁Schreib','t','▁lieber','▁an','▁t','.','te','ster','@','ex','a','mple','.','in','vali','d','.','</s>'];
+
+const THREAD_OUTPUT: TokenClassificationItem[] = ([
+  [3,'B-PERSON_NAME',1],[4,'I-PERSON_NAME',1],[5,'I-PERSON_NAME',1],
+  [6,'B-EMAIL_ADDRESS',0.994],[7,'B-EMAIL_ADDRESS',0.491],[8,'B-EMAIL_ADDRESS',0.986],[9,'B-EMAIL_ADDRESS',0.959],
+  [11,'B-ORGANIZATION_NAME',0.993],[12,'I-ORGANIZATION_NAME',0.938],[13,'I-ORGANIZATION_NAME',0.982],[14,'I-ORGANIZATION_NAME',0.978],[15,'I-ORGANIZATION_NAME',0.992],[16,'I-ORGANIZATION_NAME',0.995],[17,'I-ORGANIZATION_NAME',0.993],
+  [21,'B-PERSON_NAME',0.999],[22,'I-PERSON_NAME',0.997],[23,'I-PERSON_NAME',0.999],
+  [25,'B-EMAIL_ADDRESS',0.963],[26,'B-EMAIL_ADDRESS',0.943],[28,'B-EMAIL_ADDRESS',0.839],[29,'B-EMAIL_ADDRESS',0.835],
+  [31,'B-ORGANIZATION_NAME',0.981],[32,'I-ORGANIZATION_NAME',0.799],[33,'I-ORGANIZATION_NAME',0.956],[34,'I-ORGANIZATION_NAME',0.963],[35,'I-ORGANIZATION_NAME',0.981],[36,'I-ORGANIZATION_NAME',0.986],[37,'I-ORGANIZATION_NAME',0.984],
+  [40,'B-PERSON_NAME',1],[41,'I-PERSON_NAME',1],[42,'I-PERSON_NAME',1],
+  [44,'B-EMAIL_ADDRESS',0.989],[45,'B-EMAIL_ADDRESS',0.394],[46,'B-EMAIL_ADDRESS',0.928],[47,'B-EMAIL_ADDRESS',0.84],
+  [49,'B-ORGANIZATION_NAME',0.987],[50,'B-ORGANIZATION_NAME',0.553],[51,'I-ORGANIZATION_NAME',0.941],[52,'I-ORGANIZATION_NAME',0.982],[53,'I-ORGANIZATION_NAME',0.987],[54,'I-ORGANIZATION_NAME',0.989],[55,'I-ORGANIZATION_NAME',0.989],
+  [81,'B-EMAIL_ADDRESS',0.984],[82,'B-EMAIL_ADDRESS',0.718],[83,'B-EMAIL_ADDRESS',0.979],[84,'B-EMAIL_ADDRESS',0.916],
+  [86,'B-ORGANIZATION_NAME',0.98],[87,'B-ORGANIZATION_NAME',0.7],[88,'I-ORGANIZATION_NAME',0.931],[89,'I-ORGANIZATION_NAME',0.965],[90,'I-ORGANIZATION_NAME',0.987],[91,'I-ORGANIZATION_NAME',0.99],[92,'I-ORGANIZATION_NAME',0.987],
+] as [number, string, number][]).map(([index, entity, score]) => ({
+  index,
+  entity,
+  score,
+  word: THREAD_PIECES[index],
+}));
+
+function spansForThread() {
+  const ranges = alignTokensToText(THREAD_TEXT, THREAD_PIECES);
+  return alignedTokensToSpans(THREAD_TEXT, THREAD_OUTPUT, ranges, 'bardsai');
+}
+
+describe('alignedTokensToSpans — mislocated-span regression', () => {
+  const shown = applyNerThresholdPolicy(spansForThread(), 'bardsai');
+  const texts = shown.map((span) => span.text);
+
+  test('the fixture really does contain a one-character address fragment', () => {
+    // Guards the fixture itself: if a future capture loses this shape, the
+    // regression below stops testing anything.
+    expect(THREAD_PIECES[81]).toBe('▁t');
+    expect(THREAD_OUTPUT.find((item) => item.index === 81)?.entity).toBe('B-EMAIL_ADDRESS');
+  });
+
+  test('the model labels the German words O, so no span may cover them', () => {
+    const labelled = new Set(THREAD_OUTPUT.map((item) => item.index));
+    expect(labelled.has(65)).toBe(false); // ▁fällt
+    expect(labelled.has(75)).toBe(false); // ▁wieder
+
+    expect(texts).not.toContain('fällt');
+    expect(texts).not.toContain('wieder');
+    expect(texts.some((text) => /fällt|wieder|leider|Oktober|Termin|Rückmeldung/.test(text))).toBe(false);
+  });
+
+  test('recovers each address in full, local part and domain together', () => {
+    expect(texts).toEqual(
+      expect.arrayContaining([
+        'max.muster@example.invalid',
+        'erika.beispiel@example.invalid',
+        'klaus.muster@example.invalid',
+        't.tester@example.invalid',
+      ])
+    );
+  });
+
+  test('keeps the people separate instead of gluing them across the comma', () => {
+    expect(texts).toEqual(expect.arrayContaining(['Max Muster', 'Erika Beispiel', 'Klaus Muster']));
+    expect(texts).not.toContain('Erika Beispiel, Klaus Muster');
+  });
+
+  test('never runs a span across a line break', () => {
+    for (const span of shown) {
+      expect(span.text).not.toContain('\n');
+    }
+  });
+
+  test('every byte offset round-trips to the span text', () => {
+    for (const span of shown) {
+      expect(sliceTextByByteOffsets(THREAD_TEXT, span.start, span.end)).toBe(span.text);
+    }
+  });
+
+  test('scores the span from its opening token, keeping real addresses above the 0.80 gate', () => {
+    const email = shown.find((span) => span.text === 'max.muster@example.invalid')!;
+    // Member scores are [0.994, 0.491, 0.986, 0.959, …]; the mean would sit
+    // under the EMAIL threshold and drop a genuine address.
+    expect(email.score).toBeCloseTo(0.994, 3);
+    expect(email.entity_type).toBe('EMAIL');
+  });
+
+  test('nothing is lost to the threshold gate on clean input', () => {
+    expect(spansForThread()).toHaveLength(shown.length);
+  });
+});
+
+describe('alignedTokensToSpans — grouping rules', () => {
+  function build(text: string, tokens: string[], labels: Record<number, [string, number]>) {
+    const ranges = alignTokensToText(text, tokens);
+    const output: TokenClassificationItem[] = Object.entries(labels).map(([index, [entity, score]]) => ({
+      index: Number(index),
+      entity,
+      score,
+      word: tokens[Number(index)],
+    }));
+    return alignedTokensToSpans(text, output, ranges, 'bardsai');
+  }
+
+  test('joins flush sub-word pieces into one span', () => {
+    const text = 'Kontakt max.muster@example.invalid';
+    const tokens = ['▁Kontakt', '▁max', '.', 'mu', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
+    const spans = build(text, tokens, {
+      1: ['B-EMAIL_ADDRESS', 0.99], 2: ['B-EMAIL_ADDRESS', 0.5], 3: ['B-EMAIL_ADDRESS', 0.6],
+      4: ['B-EMAIL_ADDRESS', 0.6], 5: ['B-EMAIL_ADDRESS', 0.6], 6: ['B-EMAIL_ADDRESS', 0.9],
+      7: ['B-EMAIL_ADDRESS', 0.9], 8: ['B-EMAIL_ADDRESS', 0.9], 9: ['B-EMAIL_ADDRESS', 0.9],
+      10: ['B-EMAIL_ADDRESS', 0.9], 11: ['B-EMAIL_ADDRESS', 0.9], 12: ['B-EMAIL_ADDRESS', 0.9],
+    });
+
+    expect(spans).toEqual([
+      expect.objectContaining({ entity_type: 'EMAIL', text: 'max.muster@example.invalid', score: 0.99 }),
+    ]);
+  });
+
+  test('joins multi-word names across a single space', () => {
+    const text = 'Cc: Erika Beispiel, Klaus Muster';
+    const tokens = ['▁C', 'c', ':', '▁Erik', 'a', '▁Beispiel', ',', '▁Klaus', '▁Must', 'er'];
+    const spans = build(text, tokens, {
+      3: ['B-PERSON_NAME', 0.99], 4: ['I-PERSON_NAME', 0.98], 5: ['I-PERSON_NAME', 0.98],
+      7: ['B-PERSON_NAME', 0.97], 8: ['I-PERSON_NAME', 0.96], 9: ['I-PERSON_NAME', 0.96],
+    });
+
+    expect(spans).toEqual([
+      expect.objectContaining({ entity_type: 'PERSON', text: 'Erika Beispiel' }),
+      expect.objectContaining({ entity_type: 'PERSON', text: 'Klaus Muster' }),
+    ]);
+  });
+
+  test('stitches an EMAIL local part onto the ORGANIZATION the model made of its domain', () => {
+    const text = 'Mail an t.tester@example.invalid bitte';
+    const tokens = ['▁Mail', '▁an', '▁t', '.', 'te', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd', '▁bitte'];
+    const spans = build(text, tokens, {
+      2: ['B-EMAIL_ADDRESS', 0.98], 3: ['B-EMAIL_ADDRESS', 0.72], 4: ['B-EMAIL_ADDRESS', 0.98],
+      5: ['B-EMAIL_ADDRESS', 0.92], 6: ['B-EMAIL_ADDRESS', 0.9],
+      7: ['B-ORGANIZATION_NAME', 0.95], 8: ['I-ORGANIZATION_NAME', 0.95], 9: ['I-ORGANIZATION_NAME', 0.95],
+      10: ['I-ORGANIZATION_NAME', 0.95], 11: ['I-ORGANIZATION_NAME', 0.95], 12: ['I-ORGANIZATION_NAME', 0.95],
+      13: ['I-ORGANIZATION_NAME', 0.95],
+    });
+
+    expect(spans).toEqual([
+      expect.objectContaining({
+        entity_type: 'EMAIL',
+        text: 't.tester@example.invalid',
+        score: 0.98,
+      }),
+    ]);
+  });
+
+  test('stitches across an unlabelled @ as well', () => {
+    const text = 'An: verteiler-3@example.invalid';
+    const tokens = ['▁An', ':', '▁verte', 'iler', '-3', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
+    const spans = build(text, tokens, {
+      2: ['B-EMAIL_ADDRESS', 0.99], 3: ['B-EMAIL_ADDRESS', 0.6], 4: ['B-EMAIL_ADDRESS', 0.4],
+      6: ['B-ORGANIZATION_NAME', 0.9], 7: ['I-ORGANIZATION_NAME', 0.9], 8: ['I-ORGANIZATION_NAME', 0.9],
+      9: ['I-ORGANIZATION_NAME', 0.9], 10: ['I-ORGANIZATION_NAME', 0.9], 11: ['I-ORGANIZATION_NAME', 0.9],
+      12: ['I-ORGANIZATION_NAME', 0.9],
+    });
+
+    expect(spans).toEqual([
+      expect.objectContaining({ entity_type: 'EMAIL', text: 'verteiler-3@example.invalid' }),
+    ]);
+  });
+
+  test('closes a mislabelled gap inside one identifier rather than half-redacting it', () => {
+    // The model sometimes drops a different label into the middle of an
+    // identifier. Left split, the anonymizer would redact both ends and publish
+    // the middle in the clear.
+    const text = 'Schreibt an t.tester@example.invalid';
+    const tokens = ['▁Schreib', 't', '▁an', '▁t', '.', 'te', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
+    const spans = build(text, tokens, {
+      3: ['B-EMAIL_ADDRESS', 0.98], 4: ['B-EMAIL_ADDRESS', 0.9],
+      5: ['I-ACCOUNT_IDENTIFIER', 0.44], 6: ['I-ACCOUNT_IDENTIFIER', 0.6],
+      7: ['B-EMAIL_ADDRESS', 0.9], 8: ['B-EMAIL_ADDRESS', 0.9], 9: ['B-EMAIL_ADDRESS', 0.9],
+      10: ['B-EMAIL_ADDRESS', 0.9], 11: ['B-EMAIL_ADDRESS', 0.9], 12: ['B-EMAIL_ADDRESS', 0.9],
+      13: ['B-EMAIL_ADDRESS', 0.9], 14: ['B-EMAIL_ADDRESS', 0.9],
+    });
+
+    expect(spans.map((span) => span.text)).toContain('t.tester@example.invalid');
+  });
+
+  test('completes a half-labelled word but stops at a non-word boundary', () => {
+    const text = 'Muster schrieb an max.muster@example.invalid';
+    const tokens = ['▁Must', 'er', '▁schrieb', '▁an', '▁max', '.', 'mu', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
+    const spans = build(text, tokens, {
+      0: ['B-PERSON_NAME', 0.99],
+      4: ['B-EMAIL_ADDRESS', 0.99], 5: ['B-EMAIL_ADDRESS', 0.6], 6: ['B-EMAIL_ADDRESS', 0.6],
+      7: ['B-EMAIL_ADDRESS', 0.6], 8: ['B-EMAIL_ADDRESS', 0.6],
+    });
+
+    // `▁Must` alone is completed to the whole word...
+    expect(spans[0]).toEqual(expect.objectContaining({ entity_type: 'PERSON', text: 'Muster' }));
+    // ...but a span ending on `@` is not allowed to grow into the domain.
+    expect(spans[1].text).toBe('max.muster@');
+  });
+
+  test('drops predictions whose token could not be placed', () => {
+    const text = 'Erika Muster';
+    const ranges = alignTokensToText(text, ['▁Erika', '▁Muster']);
+    const spans = alignedTokensToSpans(
+      text,
+      [
+        { index: 0, entity: 'B-PERSON_NAME', score: 0.99, word: '▁Erika' },
+        { index: 7, entity: 'B-EMAIL_ADDRESS', score: 0.99, word: 'ghost' },
+      ],
+      ranges,
+      'bardsai'
+    );
+
+    expect(spans).toEqual([expect.objectContaining({ text: 'Erika' })]);
+  });
+
+  test('ignores items with no index, which cannot be located', () => {
+    const ranges = alignTokensToText('Erika Muster', ['▁Erika', '▁Muster']);
+    expect(
+      alignedTokensToSpans('Erika Muster', [{ entity_group: 'PERSON_NAME', score: 0.99, word: 'Erika' }], ranges)
+    ).toEqual([]);
+  });
+});
+
+describe('chunkTextByTokens', () => {
+  /** Whitespace tokenizer that mimics Metaspace word-initial markers. */
+  function stubTokenizer(modelMaxLength?: number): NerTokenizerLike {
+    return {
+      model_max_length: modelMaxLength,
+      tokenize(text: string): string[] {
+        return text.split(/(\s+)/).filter((part) => part.trim().length > 0).map((word) => `▁${word}`);
+      },
+    };
+  }
+
+  test('returns a single chunk when the text fits the token budget', () => {
+    const text = 'Erika Muster schreibt an info@example.invalid';
+    const chunks = chunkTextByTokens(text, stubTokenizer(512), { maxTokens: 100 })!;
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatchObject({ text, startChar: 0, endChar: text.length, startByte: 0 });
+  });
+
+  test('splits on token boundaries and loses no source text', () => {
+    const words = Array.from({ length: 200 }, (_, i) => `wort${i}`);
+    const text = words.join(' ');
+    const chunks = chunkTextByTokens(text, stubTokenizer(512), { maxTokens: 40, overlapTokens: 5 })!;
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text).toBe(text.slice(chunk.startChar, chunk.endChar));
+      // A chunk boundary never lands inside a word.
+      expect(chunk.text.trim().split(/\s+/).every((word) => words.includes(word))).toBe(true);
+    }
+    expect(chunks[0].startChar).toBe(0);
+    expect(chunks[chunks.length - 1].endChar).toBe(text.length);
+  });
+
+  test('respects the encoder position limit rather than a character budget', () => {
+    // 5000 characters of German is ~1470 tokens on this tokenizer — far past the
+    // 512 positions the model actually reads.
+    const text = Array.from({ length: 900 }, (_, i) => `begriff${i}`).join(' ');
+    const chunks = chunkTextByTokens(text, stubTokenizer(512))!;
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.trim().split(/\s+/).length).toBeLessThanOrEqual(480);
+    }
+  });
+
+  test('returns null when the tokenizer throws so the caller can fall back', () => {
+    const throwing: NerTokenizerLike = {
+      tokenize() {
+        throw new Error('tokenizer unavailable');
+      },
+    };
+
+    expect(chunkTextByTokens('some text', throwing)).toBeNull();
+  });
+
+  test('returns an empty plan for empty text', () => {
+    expect(chunkTextByTokens('', stubTokenizer())).toEqual([]);
+  });
+});
+
+describe('transformers provider — offset path selection', () => {
+  const extensionUrl = (path: string) => `chrome-extension://test/${path}`;
+
+  function makeEnv(): any {
+    return {
+      allowRemoteModels: true,
+      allowLocalModels: false,
+      localModelPath: '',
+      useBrowserCache: true,
+      useFSCache: true,
+      useWasmCache: true,
+      backends: { onnx: { wasm: {} } },
+    };
+  }
+
+  beforeEach(() => {
+    resetNerProviderCachesForTests();
+  });
+
+  test('asks for raw per-token output when a tokenizer is available to align with', async () => {
+    const text = 'Mail an info@example.invalid';
+    const classifier: any = jest.fn().mockResolvedValue([
+      { index: 2, entity: 'B-EMAIL_ADDRESS', score: 0.99, word: '▁info' },
+      { index: 3, entity: 'B-EMAIL_ADDRESS', score: 0.95, word: '@' },
+      { index: 4, entity: 'B-EMAIL_ADDRESS', score: 0.95, word: 'example' },
+      { index: 5, entity: 'B-EMAIL_ADDRESS', score: 0.95, word: '.' },
+      { index: 6, entity: 'B-EMAIL_ADDRESS', score: 0.95, word: 'invalid' },
+    ]);
+    classifier.tokenizer = {
+      model_max_length: 512,
+      tokenize: () => ['▁Mail', '▁an', '▁info', '@', 'example', '.', 'invalid'],
+    };
+
+    const provider = createTransformersNerProvider({
+      modelKey: 'bardsai',
+      getExtensionUrl: extensionUrl,
+      assetExists: jest.fn().mockResolvedValue(true),
+      detectWebGpu: jest.fn().mockResolvedValue(false),
+      loadTransformers: jest
+        .fn()
+        .mockResolvedValue({ env: makeEnv(), pipeline: jest.fn().mockResolvedValue(classifier) }),
+    });
+
+    const spans = await provider.detect(text);
+
+    expect(classifier).toHaveBeenCalledWith(text, { aggregation_strategy: 'none' });
+    expect(spans).toEqual([
+      expect.objectContaining({ entity_type: 'EMAIL', text: 'info@example.invalid', score: 0.99 }),
+    ]);
+  });
+
+  test('falls back to aggregated output when the pipeline exposes no tokenizer', async () => {
+    const classifier: any = jest.fn().mockResolvedValue([]);
+
+    const provider = createTransformersNerProvider({
+      modelKey: 'bardsai',
+      getExtensionUrl: extensionUrl,
+      assetExists: jest.fn().mockResolvedValue(true),
+      detectWebGpu: jest.fn().mockResolvedValue(false),
+      loadTransformers: jest
+        .fn()
+        .mockResolvedValue({ env: makeEnv(), pipeline: jest.fn().mockResolvedValue(classifier) }),
+    });
+
+    await provider.detect('no pii here');
+
+    expect(classifier).toHaveBeenCalledWith('no pii here', { aggregation_strategy: 'simple' });
+  });
+});

--- a/tests/offscreen/ner-aligned-spans.test.ts
+++ b/tests/offscreen/ner-aligned-spans.test.ts
@@ -2,6 +2,7 @@ import {
   alignedTokensToSpans,
   applyNerThresholdPolicy,
   chunkTextByTokens,
+  chunkTextForNer,
   createTransformersNerProvider,
   resetNerProviderCachesForTests,
   type NerTokenizerLike,
@@ -239,6 +240,66 @@ describe('alignedTokensToSpans — grouping rules', () => {
     expect(spans.map((span) => span.text)).toContain('t.tester@example.invalid');
   });
 
+  test('keeps a repaired identifier above threshold when its tail is confident', () => {
+    const text = 'pin.secret.code';
+    const spans = build(text, ['▁pin', '.', 'secret', '.', 'code'], {
+      0: ['B-AUTH_SECRET', 0.4], 1: ['B-AUTH_SECRET', 0.4],
+      2: ['B-ACCOUNT_IDENTIFIER', 0.99],
+      3: ['B-AUTH_SECRET', 0.99], 4: ['B-AUTH_SECRET', 0.99],
+    });
+    expect(applyNerThresholdPolicy(spans, 'bardsai')).toEqual([
+      expect.objectContaining({ text, entity_type: 'PASSWORD', score: 0.99 }),
+    ]);
+  });
+
+  test('preserves a passing middle when neither endpoint can support a repair', () => {
+    const spans = build('pin.secret.code', ['▁pin', '.', 'secret', '.', 'code'], {
+      0: ['B-AUTH_SECRET', 0.4], 1: ['B-AUTH_SECRET', 0.4],
+      2: ['B-ACCOUNT_IDENTIFIER', 0.99],
+      3: ['B-AUTH_SECRET', 0.4], 4: ['B-AUTH_SECRET', 0.4],
+    });
+    expect(applyNerThresholdPolicy(spans, 'bardsai')).toEqual([
+      expect.objectContaining({ text: 'secret', entity_type: 'USERNAME' }),
+    ]);
+  });
+
+  test('scores each word in a name instead of dropping confident later words', () => {
+    const spans = build('Ada Lovelace', ['▁Ada', '▁Love', 'lace'], {
+      0: ['B-PERSON_NAME', 0.5], 1: ['I-PERSON_NAME', 0.99], 2: ['I-PERSON_NAME', 0.99],
+    });
+    expect(applyNerThresholdPolicy(spans, 'bardsai')).toEqual([
+      expect.objectContaining({ text: 'Ada Lovelace', entity_type: 'PERSON' }),
+    ]);
+  });
+
+  test('stitches only the domain and keeps the following company separate', () => {
+    const text = 'a@example.invalid Müller GmbH';
+    const spans = build(text, ['▁a', '@', 'example', '.', 'invalid', '▁Müller', '▁GmbH'], {
+      0: ['B-EMAIL_ADDRESS', 0.99],
+      2: ['B-ORGANIZATION_NAME', 0.95], 3: ['I-ORGANIZATION_NAME', 0.95],
+      4: ['I-ORGANIZATION_NAME', 0.95], 5: ['B-ORGANIZATION_NAME', 0.99],
+      6: ['I-ORGANIZATION_NAME', 0.99],
+    });
+    expect(applyNerThresholdPolicy(spans, 'bardsai')).toEqual([
+      expect.objectContaining({ text: 'a@example.invalid', entity_type: 'EMAIL' }),
+      expect.objectContaining({ text: 'Müller GmbH', entity_type: 'ORGANIZATION' }),
+    ]);
+    for (const span of spans) {
+      expect(sliceTextByByteOffsets(text, span.start, span.end)).toBe(span.text);
+    }
+  });
+
+  test('does not lose a passing domain to a failing email stitch', () => {
+    const spans = build('a@example.invalid', ['▁a', '@', 'example', '.', 'invalid'], {
+      0: ['B-EMAIL_ADDRESS', 0.4],
+      2: ['B-ORGANIZATION_NAME', 0.99], 3: ['I-ORGANIZATION_NAME', 0.99],
+      4: ['I-ORGANIZATION_NAME', 0.99],
+    });
+    expect(applyNerThresholdPolicy(spans, 'bardsai')).toEqual([
+      expect.objectContaining({ text: 'example.invalid', entity_type: 'ORGANIZATION' }),
+    ]);
+  });
+
   test('completes a half-labelled word but stops at a non-word boundary', () => {
     const text = 'Muster schrieb an max.muster@example.invalid';
     const tokens = ['▁Must', 'er', '▁schrieb', '▁an', '▁max', '.', 'mu', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
@@ -275,6 +336,21 @@ describe('alignedTokensToSpans — grouping rules', () => {
     expect(
       alignedTokensToSpans('Erika Muster', [{ entity_group: 'PERSON_NAME', score: 0.99, word: 'Erika' }], ranges)
     ).toEqual([]);
+  });
+});
+
+describe('character fallback Unicode boundaries', () => {
+  test.each([1, 3, 5])('preserves code points and byte offsets with a %i-character budget', (maxChunkChars) => {
+    const text = '😀😀 Müller 😀';
+    const chunks = chunkTextForNer(text, { maxChunkChars, overlapChars: 1 });
+    let coveredUntil = 0;
+    for (const chunk of chunks) {
+      expect(chunk.startChar).toBeLessThanOrEqual(coveredUntil);
+      coveredUntil = Math.max(coveredUntil, chunk.endChar);
+      expect(/^[\uDC00-\uDFFF]|[\uD800-\uDBFF]$/u.test(chunk.text)).toBe(false);
+      expect(sliceTextByByteOffsets(text, chunk.startByte, chunk.endByte)).toBe(chunk.text);
+    }
+    expect(coveredUntil).toBe(text.length);
   });
 });
 
@@ -414,6 +490,56 @@ describe('transformers provider — offset path selection', () => {
     expect(spans).toEqual([
       expect.objectContaining({ entity_type: 'EMAIL', text: 'info@example.invalid', score: 0.99 }),
     ]);
+  });
+
+  test('checks every final inference input even when alignment fails', async () => {
+    const text = '☃ '.repeat(260) + 'Anna Müller' + ' ☃'.repeat(740);
+    const inputs: string[] = [];
+    // Each symbol costs two positions, but normalization prevents the aligner
+    // from placing it. The name sits in the old 800-character fallback's blind spot.
+    const tokenizer: NerTokenizerLike = {
+      model_max_length: 512,
+      tokenize(input, options) {
+        const pieces = input.match(/☃|Anna|Müller/g)?.flatMap((word) =>
+          word === '☃' ? ['▁', 'unplaceable-symbol'] : [`▁${word}`]
+        ) ?? [];
+        return options?.add_special_tokens ? ['<s>', ...pieces, '</s>'] : pieces;
+      },
+    };
+    const classifier: any = jest.fn(async (input: string, options: any) => {
+      inputs.push(input);
+      expect(tokenizer.tokenize(input, { add_special_tokens: true }).length).toBeLessThanOrEqual(512);
+      if (!input.includes('Anna Müller')) return [];
+      const pieces = tokenizer.tokenize(input, { add_special_tokens: true });
+      return options.aggregation_strategy === 'none'
+        ? [
+            { index: pieces.indexOf('▁Anna'), entity: 'B-PERSON_NAME', score: 0.99, word: 'Anna' },
+            { index: pieces.indexOf('▁Müller'), entity: 'I-PERSON_NAME', score: 0.99, word: 'Müller' },
+          ]
+        : [{ entity_group: 'PERSON_NAME', score: 0.99, word: 'Anna Müller' }];
+    });
+    classifier.tokenizer = tokenizer;
+    const provider = createTransformersNerProvider({
+      modelKey: 'bardsai', getExtensionUrl: extensionUrl,
+      assetExists: async () => true, detectWebGpu: async () => false,
+      loadTransformers: async () => ({ env: makeEnv(), pipeline: async () => classifier }),
+    });
+    const spans = await provider.detect(text);
+    expect(spans).toEqual([expect.objectContaining({ text: 'Anna Müller', entity_type: 'PERSON' })]);
+    expect(sliceTextByByteOffsets(text, spans[0].start, spans[0].end)).toBe('Anna Müller');
+    expect(inputs.length).toBeGreaterThan(1);
+  });
+
+  test('does not classify an unverified input when tokenization throws', async () => {
+    const classifier: any = jest.fn().mockResolvedValue([]);
+    classifier.tokenizer = { tokenize: () => { throw new Error('broken tokenizer'); } };
+    const provider = createTransformersNerProvider({
+      modelKey: 'bardsai', getExtensionUrl: extensionUrl,
+      assetExists: async () => true, detectWebGpu: async () => false,
+      loadTransformers: async () => ({ env: makeEnv(), pipeline: async () => classifier }),
+    });
+    await expect(provider.detect('Anna Müller')).rejects.toThrow(/token/i);
+    expect(classifier).not.toHaveBeenCalled();
   });
 
   test('falls back to aggregated output when the pipeline exposes no tokenizer', async () => {

--- a/tests/offscreen/ner-aligned-spans.test.ts
+++ b/tests/offscreen/ner-aligned-spans.test.ts
@@ -270,6 +270,32 @@ describe('chunkTextByTokens', () => {
     }
   });
 
+  test('counts pieces the aligner could not place against the chunk budget', () => {
+    // Every sixth word comes back as <unk>, which the aligner cannot place but
+    // the encoder still charges a position for. Budgeting by placed tokens alone
+    // let a nominal 40-token chunk carry ~48 real pieces.
+    const unkTokenizer: NerTokenizerLike = {
+      model_max_length: 512,
+      tokenize(text: string): string[] {
+        return text
+          .split(/(\s+)/)
+          .filter((part) => part.trim().length > 0)
+          .map((word, index) => (index % 6 === 5 ? '<unk>' : `\u2581${word}`));
+      },
+    };
+
+    const text = Array.from({ length: 300 }, (_, i) => `wort${i}`).join(' ');
+    const chunks = chunkTextByTokens(text, unkTokenizer, { maxTokens: 40, overlapTokens: 5 })!;
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(unkTokenizer.tokenize(chunk.text).length).toBeLessThanOrEqual(40);
+    }
+    // and still no source character falls outside every chunk
+    expect(chunks[0].startChar).toBe(0);
+    expect(chunks[chunks.length - 1].endChar).toBe(text.length);
+  });
+
   test('returns null when the tokenizer throws so the caller can fall back', () => {
     const throwing: NerTokenizerLike = {
       tokenize() {

--- a/tests/offscreen/ner-aligned-spans.test.ts
+++ b/tests/offscreen/ner-aligned-spans.test.ts
@@ -185,6 +185,60 @@ describe('alignedTokensToSpans — grouping rules', () => {
     ]);
   });
 
+  test('does not bridge two people across a bare comma', () => {
+    // The bridge that rejoins a mislabelled identifier must not reach across the
+    // boundary between two values. Without a space to stop it, an earlier rule
+    // that asked only for "no whitespace" merged these into one span, so a
+    // single placeholder stood for two distinct people.
+    const text = 'Mueller,Schmidt';
+    const spans = build(text, ['\u2581Mueller', ',', 'Schmidt'], {
+      0: ['B-PERSON_NAME', 0.99],
+      2: ['B-PERSON_NAME', 0.99],
+    });
+
+    expect(spans.map((span) => span.text)).toEqual(['Mueller', 'Schmidt']);
+  });
+
+  test('does not bridge two places across a bracket', () => {
+    const text = 'Berlin(Muenchen)';
+    const spans = build(text, ['\u2581Berlin', '(', 'Muenchen', ')'], {
+      0: ['B-LOCATION', 0.99],
+      2: ['B-LOCATION', 0.99],
+    });
+
+    expect(spans.map((span) => span.text)).toEqual(['Berlin', 'Muenchen']);
+  });
+
+  test('two addresses separated by only a comma stay two spans', () => {
+    const text = 'a@b.example,c@d.example';
+    const tokens = ['\u2581a', '@', 'b', '.', 'example', ',', 'c', '@', 'd', '.', 'example'];
+    const spans = build(text, tokens, {
+      0: ['B-EMAIL_ADDRESS', 0.99], 1: ['B-EMAIL_ADDRESS', 0.9], 2: ['B-EMAIL_ADDRESS', 0.9],
+      3: ['B-EMAIL_ADDRESS', 0.9], 4: ['B-EMAIL_ADDRESS', 0.9],
+      6: ['B-EMAIL_ADDRESS', 0.99], 7: ['B-EMAIL_ADDRESS', 0.9], 8: ['B-EMAIL_ADDRESS', 0.9],
+      9: ['B-EMAIL_ADDRESS', 0.9], 10: ['B-EMAIL_ADDRESS', 0.9],
+    });
+
+    expect(spans.map((span) => span.text)).toEqual(['a@b.example', 'c@d.example']);
+  });
+
+  test('closes a mislabelled gap inside one identifier rather than half-redacting it', () => {
+    // The model sometimes drops a different label into the middle of an
+    // identifier. Left split, the anonymizer would redact both ends and publish
+    // the middle in the clear.
+    const text = 'Schreibt an t.tester@example.invalid';
+    const tokens = ['▁Schreib', 't', '▁an', '▁t', '.', 'te', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
+    const spans = build(text, tokens, {
+      3: ['B-EMAIL_ADDRESS', 0.98], 4: ['B-EMAIL_ADDRESS', 0.9],
+      5: ['I-ACCOUNT_IDENTIFIER', 0.44], 6: ['I-ACCOUNT_IDENTIFIER', 0.6],
+      7: ['B-EMAIL_ADDRESS', 0.9], 8: ['B-EMAIL_ADDRESS', 0.9], 9: ['B-EMAIL_ADDRESS', 0.9],
+      10: ['B-EMAIL_ADDRESS', 0.9], 11: ['B-EMAIL_ADDRESS', 0.9], 12: ['B-EMAIL_ADDRESS', 0.9],
+      13: ['B-EMAIL_ADDRESS', 0.9], 14: ['B-EMAIL_ADDRESS', 0.9],
+    });
+
+    expect(spans.map((span) => span.text)).toContain('t.tester@example.invalid');
+  });
+
   test('completes a half-labelled word but stops at a non-word boundary', () => {
     const text = 'Muster schrieb an max.muster@example.invalid';
     const tokens = ['▁Must', 'er', '▁schrieb', '▁an', '▁max', '.', 'mu', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];

--- a/tests/offscreen/ner-aligned-spans.test.ts
+++ b/tests/offscreen/ner-aligned-spans.test.ts
@@ -240,11 +240,39 @@ describe('alignedTokensToSpans — grouping rules', () => {
     expect(spans.map((span) => span.text)).toContain('t.tester@example.invalid');
   });
 
+  test.each([0.6, 0.99])('preserves a middle username at confidence %s between passing passwords', (score) => {
+    const text = 'pin.secret.code';
+    const spans = build(text, ['▁pin', '.', 'secret', '.', 'code'], {
+      0: ['B-AUTH_SECRET', 0.99], 1: ['B-AUTH_SECRET', 0.99],
+      2: ['B-ACCOUNT_IDENTIFIER', score],
+      3: ['B-AUTH_SECRET', 0.99], 4: ['B-AUTH_SECRET', 0.99],
+    });
+    const passing = applyNerThresholdPolicy(spans, 'bardsai');
+    expect(passing).toEqual([
+      expect.objectContaining({ start: 0, end: 4, text: 'pin.', entity_type: 'PASSWORD' }),
+      expect.objectContaining({ start: 4, end: 10, text: 'secret', entity_type: 'USERNAME', score }),
+      expect.objectContaining({ start: 10, end: 15, text: '.code', entity_type: 'PASSWORD' }),
+    ]);
+    expect(passing.map((span) => span.text).join('')).toBe(text);
+  });
+
+  test('preserves a passing middle even when only the password tail is confident', () => {
+    const spans = build('pin.secret.code', ['▁pin', '.', 'secret', '.', 'code'], {
+      0: ['B-AUTH_SECRET', 0.4], 1: ['B-AUTH_SECRET', 0.4],
+      2: ['B-ACCOUNT_IDENTIFIER', 0.99],
+      3: ['B-AUTH_SECRET', 0.99], 4: ['B-AUTH_SECRET', 0.99],
+    });
+    expect(applyNerThresholdPolicy(spans, 'bardsai')).toEqual([
+      expect.objectContaining({ text: 'secret', entity_type: 'USERNAME', score: 0.99 }),
+      expect.objectContaining({ text: '.code', entity_type: 'PASSWORD', score: 0.99 }),
+    ]);
+  });
+
   test('keeps a repaired identifier above threshold when its tail is confident', () => {
     const text = 'pin.secret.code';
     const spans = build(text, ['▁pin', '.', 'secret', '.', 'code'], {
       0: ['B-AUTH_SECRET', 0.4], 1: ['B-AUTH_SECRET', 0.4],
-      2: ['B-ACCOUNT_IDENTIFIER', 0.99],
+      2: ['B-ACCOUNT_IDENTIFIER', 0.59],
       3: ['B-AUTH_SECRET', 0.99], 4: ['B-AUTH_SECRET', 0.99],
     });
     expect(applyNerThresholdPolicy(spans, 'bardsai')).toEqual([

--- a/tests/offscreen/ner-aligned-spans.test.ts
+++ b/tests/offscreen/ner-aligned-spans.test.ts
@@ -185,23 +185,6 @@ describe('alignedTokensToSpans — grouping rules', () => {
     ]);
   });
 
-  test('closes a mislabelled gap inside one identifier rather than half-redacting it', () => {
-    // The model sometimes drops a different label into the middle of an
-    // identifier. Left split, the anonymizer would redact both ends and publish
-    // the middle in the clear.
-    const text = 'Schreibt an t.tester@example.invalid';
-    const tokens = ['▁Schreib', 't', '▁an', '▁t', '.', 'te', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
-    const spans = build(text, tokens, {
-      3: ['B-EMAIL_ADDRESS', 0.98], 4: ['B-EMAIL_ADDRESS', 0.9],
-      5: ['I-ACCOUNT_IDENTIFIER', 0.44], 6: ['I-ACCOUNT_IDENTIFIER', 0.6],
-      7: ['B-EMAIL_ADDRESS', 0.9], 8: ['B-EMAIL_ADDRESS', 0.9], 9: ['B-EMAIL_ADDRESS', 0.9],
-      10: ['B-EMAIL_ADDRESS', 0.9], 11: ['B-EMAIL_ADDRESS', 0.9], 12: ['B-EMAIL_ADDRESS', 0.9],
-      13: ['B-EMAIL_ADDRESS', 0.9], 14: ['B-EMAIL_ADDRESS', 0.9],
-    });
-
-    expect(spans.map((span) => span.text)).toContain('t.tester@example.invalid');
-  });
-
   test('completes a half-labelled word but stops at a non-word boundary', () => {
     const text = 'Muster schrieb an max.muster@example.invalid';
     const tokens = ['▁Must', 'er', '▁schrieb', '▁an', '▁max', '.', 'mu', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];

--- a/tests/offscreen/token-offsets.test.ts
+++ b/tests/offscreen/token-offsets.test.ts
@@ -1,0 +1,145 @@
+import { alignTokensToText, alignmentCoverage } from '../../src/offscreen/token-offsets';
+
+
+/** Slice `text` by every placed range, for readable assertions. */
+function placed(text: string, tokens: string[]): (string | null)[] {
+  return alignTokensToText(text, tokens).map((range) =>
+    range ? text.slice(range.start, range.end) : null
+  );
+}
+
+describe('alignTokensToText — SentencePiece / Metaspace (XLM-R)', () => {
+  test('places every piece of a shredded address', () => {
+    // The tokenizer tears one address into nine pieces, five of them one or two
+    // characters — the shape that made the old indexOf recovery drift.
+    const text = 'Von: Max Muster max.muster@example.invalid';
+    const tokens = [
+      '<s>', '▁Von', ':', '▁Max', '▁Must', 'er',
+      '▁max', '.', 'mu', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd', '</s>',
+    ];
+
+    expect(placed(text, tokens)).toEqual([
+      null, 'Von', ':', 'Max', 'Must', 'er',
+      'max', '.', 'mu', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd', null,
+    ]);
+  });
+
+  test('a one-character piece lands on its own character, not an earlier one', () => {
+    // This is the reported bug in miniature. `▁t` is the whole local part of
+    // t.tester@…; the letter `t` also appears inside `fällt` (15) and
+    // `Schreibt` (29). A forward-only indexOf grabbed the one in `fällt` and
+    // expanded it into the whole German word.
+    const text = 'Der Termin fällt aus. Schreibt an t.tester@example.invalid';
+    const tokens = [
+      '▁Der', '▁Termin', '▁fällt', '▁aus', '.', '▁Schreib', 't', '▁an',
+      '▁t', '.', 'te', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd',
+    ];
+    const ranges = alignTokensToText(text, tokens);
+
+    expect(text.charAt(15)).toBe('t'); // inside "fällt"
+    expect(text.charAt(29)).toBe('t'); // end of "Schreibt"
+    expect(text.charAt(34)).toBe('t'); // the local part
+
+    expect(ranges[6]).toEqual({ start: 29, end: 30 }); // the `t` of Schreibt
+    expect(ranges[8]).toEqual({ start: 34, end: 35 }); // the local part `t`
+    expect(text.slice(ranges[2]!.start, ranges[2]!.end)).toBe('fällt');
+  });
+
+  test('distinguishes a piece that occurs twice in the same line', () => {
+    const text = 'Max Muster max.muster@example.invalid';
+    const tokens = ['▁Max', '▁Must', 'er', '▁max', '.', 'mu', 'ster', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
+    const ranges = alignTokensToText(text, tokens);
+
+    // "Muster" the surname, then "muster" the local part — same folded text.
+    expect(ranges[1]!.start).toBe(text.indexOf('Muster'));
+    expect(ranges[5]!.start).toBe(text.indexOf('muster'));
+    expect(ranges[1]!.start).toBeLessThan(ranges[5]!.start);
+  });
+
+  test('covers every non-whitespace character of the source text', () => {
+    const text = 'Der Termin fällt leider aus und kommt frühestens im Oktober wieder.';
+    const tokens = [
+      '▁Der', '▁Termin', '▁fällt', '▁leider', '▁aus', '▁und', '▁kommt',
+      '▁früh', 'esten', 's', '▁im', '▁Oktober', '▁wieder', '.',
+    ];
+
+    const covered = new Set<number>();
+    for (const range of alignTokensToText(text, tokens)) {
+      if (!range) continue;
+      for (let i = range.start; i < range.end; i += 1) covered.add(i);
+    }
+
+    const missed = [...text].map((char, i) => (covered.has(i) || /\s/.test(char) ? '' : char)).join('');
+    expect(missed).toBe('');
+  });
+
+  test('consumes runs of whitespace, tabs and newlines between words', () => {
+    const text = 'Von:\tMax\n\nAn:   info@example.invalid';
+    const tokens = ['▁Von', ':', '▁Max', '▁An', ':', '▁info', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd'];
+
+    expect(placed(text, tokens)).toEqual([
+      'Von', ':', 'Max', 'An', ':', 'info', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd',
+    ]);
+  });
+
+  test('handles a metaspace-only piece, and keeps umlauts, quotes, currency and emoji aligned', () => {
+    // `▁` alone stands for whitespace, not content: it consumes the space so the
+    // next piece starts correctly, but claims no characters of its own.
+    const text = 'Grüße 👋 „Testfall" — 12 € an Muster';
+    const tokens = ['▁Grüße', '▁', '👋', '▁„', 'Test', 'fall', '"', '▁—', '▁12', '▁€', '▁an', '▁Must', 'er'];
+
+    expect(placed(text, tokens)).toEqual([
+      'Grüße', null, '👋', '„', 'Test', 'fall', '"', '—', '12', '€', 'an', 'Must', 'er',
+    ]);
+  });
+});
+
+describe('alignTokensToText — WordPiece (uncased DistilBERT)', () => {
+  test('folds case and accents so uncased pieces map onto the original text', () => {
+    const text = 'Erika Muster works at Muster GmbH';
+    const tokens = ['[CLS]', 'erika', 'must', '##er', 'works', 'at', 'must', '##er', 'gmbh', '[SEP]'];
+
+    expect(placed(text, tokens)).toEqual([
+      null, 'Erika', 'Must', 'er', 'works', 'at', 'Must', 'er', 'GmbH', null,
+    ]);
+  });
+
+  test('accent-stripped pieces still land on the accented original', () => {
+    const text = 'Erika Müller';
+    const tokens = ['erika', 'mu', '##ller'];
+
+    expect(placed(text, tokens)).toEqual(['Erika', 'Mü', 'ller']);
+  });
+
+  test('continuation pieces attach without consuming whitespace', () => {
+    const text = 'test_user logged in';
+    const tokens = ['test', '##_', '##user', 'logged', 'in'];
+
+    expect(placed(text, tokens)).toEqual(['test', '_', 'user', 'logged', 'in']);
+  });
+});
+
+describe('alignTokensToText — resilience', () => {
+  test('resyncs after an unknown token rather than derailing the rest of the sequence', () => {
+    const text = 'Kontakt ⛾ info@example.invalid heute';
+    const tokens = ['▁Kontakt', '<unk>', '▁info', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd', '▁heute'];
+
+    expect(placed(text, tokens)).toEqual([
+      'Kontakt', null, 'info', '@', 'ex', 'a', 'mple', '.', 'in', 'vali', 'd', 'heute',
+    ]);
+  });
+
+  test('reports coverage so callers can refuse to trust a bad alignment', () => {
+    const text = 'Erika Muster';
+    const good = alignTokensToText(text, ['▁Erika', '▁Muster']);
+    const bad = alignTokensToText(text, ['▁Zzz', '▁Qqq', '▁Www']);
+
+    expect(alignmentCoverage(good)).toBe(1);
+    expect(alignmentCoverage(bad)).toBeLessThan(0.8);
+  });
+
+  test('returns an empty result for empty input', () => {
+    expect(alignTokensToText('', [])).toEqual([]);
+    expect(alignmentCoverage([])).toBe(1);
+  });
+});

--- a/tests/offscreen/token-offsets.test.ts
+++ b/tests/offscreen/token-offsets.test.ts
@@ -131,15 +131,24 @@ describe('alignTokensToText — resilience', () => {
 
   test('reports coverage so callers can refuse to trust a bad alignment', () => {
     const text = 'Erika Muster';
-    const good = alignTokensToText(text, ['▁Erika', '▁Muster']);
-    const bad = alignTokensToText(text, ['▁Zzz', '▁Qqq', '▁Www']);
+    const goodTokens = ['▁Erika', '▁Muster'];
+    const badTokens = ['▁Zzz', '▁Qqq', '▁Www'];
 
-    expect(alignmentCoverage(good)).toBe(1);
-    expect(alignmentCoverage(bad)).toBeLessThan(0.8);
+    expect(alignmentCoverage(alignTokensToText(text, goodTokens), goodTokens)).toBe(1);
+    expect(alignmentCoverage(alignTokensToText(text, badTokens), badTokens)).toBeLessThan(0.8);
+  });
+
+  test('does not count the special tokens the post-processor adds as failures', () => {
+    const text = 'Erika Muster';
+    const tokens = ['<s>', '▁Erika', '▁Muster', '</s>'];
+
+    // Every content piece is placed; only '<s>' and '</s>' align to null. Counting
+    // those against the ratio would drop short text under the provider's gate.
+    expect(alignmentCoverage(alignTokensToText(text, tokens), tokens)).toBe(1);
   });
 
   test('returns an empty result for empty input', () => {
     expect(alignTokensToText('', [])).toEqual([]);
-    expect(alignmentCoverage([])).toBe(1);
+    expect(alignmentCoverage([], [])).toBe(1);
   });
 });

--- a/tests/offscreen/token-offsets.test.ts
+++ b/tests/offscreen/token-offsets.test.ts
@@ -152,3 +152,41 @@ describe('alignTokensToText — resilience', () => {
     expect(alignmentCoverage([], [])).toBe(1);
   });
 });
+
+describe('literal special tokens', () => {
+  test('consumes a literal mask before locating the following word', () => {
+    const text = 'Bob <mask> mask Müller ist heute hier.';
+    const tokens = ['<s>', '▁Bob', '<mask>', '▁mask', '▁Müller', '▁ist', '▁heute', '▁hier', '.', '</s>'];
+    expect(alignTokensToText(text, tokens)[3]).toEqual({ start: 11, end: 15 });
+  });
+
+  test('distinguishes an inserted start token from a literal one at the start', () => {
+    const text = '<s> s Anna';
+    const tokens = ['<s>', '<s>', '▁s', '▁Anna', '</s>'];
+    expect(alignTokensToText(text, tokens)[2]).toEqual({ start: 4, end: 5 });
+  });
+
+  test('consumes literal boundary tokens when post-processing was disabled', () => {
+    const text = '<s> s Anna';
+    const tokens = ['<s>', '▁s', '▁Anna'];
+    expect(alignTokensToText(text, tokens, { addSpecialTokens: false })[1])
+      .toEqual({ start: 4, end: 5 });
+  });
+
+  test('consumes a literal end token before a matching word', () => {
+    const text = 'Bob </s> s Anna';
+    const tokens = ['<s>', '▁Bob', '</s>', '▁s', '▁Anna', '</s>'];
+    expect(alignTokensToText(text, tokens)[3]).toEqual({ start: 9, end: 10 });
+  });
+
+  test('consumes a WordPiece mask before locating a following matching word', () => {
+    const text = 'Bob [MASK] mask Müller';
+    const tokens = ['[CLS]', 'bob', '[MASK]', 'mask', 'mü', '##ller', '[SEP]'];
+    expect(alignTokensToText(text, tokens)[3]).toEqual({ start: 11, end: 15 });
+  });
+
+  test('does not treat whitespace-only Metaspace pieces as alignment failures', () => {
+    const tokens = ['<s>', '▁', '☃', '▁', '☃', '</s>'];
+    expect(alignmentCoverage(alignTokensToText('☃ ☃', tokens), tokens)).toBe(1);
+  });
+});


### PR DESCRIPTION
**Transformers.js never fills in start/end for token-classification.** The pipeline carries a literal **"TODO: Add support for start and end" and every item arrives with both undefined**. The provider compensated by searching for each predicted fragment with indexOf, advancing a single forward-only cursor.

Recover offsets by alignment instead. `token-offsets.ts` walks the complete tokenizer piece sequence against the source text, so the cursor cannot skip ahead, and each prediction's `index` becomes a direct lookup. Handles Metaspace (XLM-R) and WordPiece, consumes whitespace at word boundaries, and resyncs after an <unk> rather than derailing. 

Span construction follows: **raw per-token output rather than the "simple" aggregation that split one address into six groups**, grouping by entity type and source adjacency instead of the model's BIO prefixes, and scoring from the opening token per **HuggingFace's 'first' strategy measured scores decay across continuation pieces, so averaging would push genuine addresses under the 0.80  for email gate.** Commas, brackets and line breaks no longer join spans. Two model-specific repairs: an EMAIL local part is stitched onto the ORGANIZATION the model makes of its domain, and a mislabeled slice inside one identifier is bridged rather than left half-redacted.

Also closes a truncation hole found. Chunking used MAX_TEXT_LENGTH (5000 characters) against a 512-position encoder; German measures ~3.4 characters per token here, so a full chunk was ~1470 tokens and roughly two thirds of a long paste was never scanned. Chunk on tokens instead, using the alignment already computed.

The legacy search survives only as a guarded fallback when no tokenizer is reachable.